### PR TITLE
Fix inventory ID parsing to handle leading zeros in sifraArtikla

### DIFF
--- a/app/Http/Controllers/ThirdPartyInvoiceController.php
+++ b/app/Http/Controllers/ThirdPartyInvoiceController.php
@@ -39,10 +39,20 @@ class ThirdPartyInvoiceController extends Controller
     private function matchInventory(array $row): ?int
     {
         // First, try to match by sifraArtikla (inventory ID from external system)
-        if (isset($row['sifraArtikla']) && !empty($row['sifraArtikla'])) {
-            $inventory = Inventory::find((int) $row['sifraArtikla']);
-            if ($inventory) {
-                return $inventory->id;
+        // The value may come as string with leading zeros (e.g., "0042" for ID 42)
+        if (isset($row['sifraArtikla'])) {
+            $rawId = $row['sifraArtikla'];
+            // Convert to string first, then parse as integer to handle:
+            // - Strings with leading zeros: "0042" -> 42
+            // - Integer values: 42 -> 42
+            // - Numeric strings: "42" -> 42
+            $parsedId = is_numeric($rawId) ? intval($rawId) : null;
+
+            if ($parsedId !== null && $parsedId > 0) {
+                $inventory = Inventory::find($parsedId);
+                if ($inventory) {
+                    return $inventory->id;
+                }
             }
         }
 


### PR DESCRIPTION
- Use is_numeric() + intval() to properly parse IDs like "0042" -> 42
- Add test case for sifraArtikla with leading zeros padding

https://claude.ai/code/session_012Nryh28j8mGdE9YpYG4iX4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, well-covered parsing tweak in third-party invoice inventory matching, plus an added feature test to prevent regressions.
> 
> **Overview**
> Fixes third-party invoice inventory matching to correctly handle `sifraArtikla` values sent as numeric strings with leading zeros by parsing with `is_numeric()` + `intval()` before `Inventory::find()`.
> 
> Adds a feature test ensuring invoices and warehouse deductions still link to the correct inventory when `sifraArtikla` is provided as a padded string (e.g., `"00042"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6337091cd42fb1a7ed44ac221c55dc4b319b23e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->