### PR TITLE
Fix konobar extraction to read from last row instead of first

### DIFF
--- a/app/Http/Controllers/ThirdPartyOrderController.php
+++ b/app/Http/Controllers/ThirdPartyOrderController.php
@@ -62,7 +62,8 @@ class ThirdPartyOrderController extends Controller
                 // Extract order-level data (lowercase field names)
                 $tableId = isset($firstRow['stoid']) ? (int) $firstRow['stoid'] : null;
                 $tableName = (string) ($firstRow['sto'] ?? 'Unknown');
-                $waiterName = $firstRow['konobar'] ?? null;
+                $lastRow = $orderRows->last();
+                $waiterName = $lastRow['konobar'] ?? null;
 
                 // Parse order datetime from datum field
                 $orderedAt = isset($firstRow['datum']) && !empty($firstRow['datum'])

--- a/tests/Feature/KitchenOrderTest.php
+++ b/tests/Feature/KitchenOrderTest.php
@@ -640,19 +640,33 @@ class KitchenOrderTest extends TestCase
     {
         $this->withoutMiddleware(VerifyExternalApiKey::class);
 
-        $payload = [[
-            'porudzbinaid' => 600004,
-            'stoid' => 100,
-            'sto' => 'Sto 1',
-            'datum' => now()->toDateTimeString(),
-            'stavkaid' => 6004,
-            'naziv' => 'Cevapi',
-            'kolicina' => 1,
-            'cena' => 300,
-            'jm' => 'kom',
-            'stampanjenalogaid' => 2,
-            'konobar' => 'Petar',
-        ]];
+        $payload = [
+            [
+                'porudzbinaid' => 600004,
+                'stoid' => 100,
+                'sto' => 'Sto 1',
+                'datum' => now()->toDateTimeString(),
+                'stavkaid' => 6004,
+                'naziv' => 'Cevapi',
+                'kolicina' => 1,
+                'cena' => 300,
+                'jm' => 'kom',
+                'stampanjenalogaid' => 1,
+            ],
+            [
+                'porudzbinaid' => 600004,
+                'stoid' => 100,
+                'sto' => 'Sto 1',
+                'datum' => now()->toDateTimeString(),
+                'stavkaid' => 6005,
+                'naziv' => 'Kafa',
+                'kolicina' => 1,
+                'cena' => 120,
+                'jm' => 'kom',
+                'stampanjenalogaid' => 2,
+                'konobar' => 'Petar',
+            ],
+        ];
 
         $response = $this->postJson('/api/third-party-order', $payload);
         $response->assertStatus(201);


### PR DESCRIPTION
The external system sends the "konobar" (waiter) field only on the last
row of the request body, not the first. Updated the controller to use
$orderRows->last() and adjusted the test to reflect the real payload
structure with multiple rows.

https://claude.ai/code/session_0137nZRmSNx2qrFy9EwQD8k4