### PR TITLE
Keep unfinished kitchen orders on display after the bill is paid

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -9,9 +9,9 @@ use Services\Pusher;
 use App\Models\Order;
 use App\Models\Sales;
 use App\Models\Invoice;
-use App\Models\KitchenOrder;
 use Services\WorkingDay;
 use Services\SalesService;
+use Services\KitchenService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -56,14 +56,12 @@ class InvoiceController extends Controller
         if ($invoice) {
             if($orderID) {
                 Order::where('id', $orderID)->delete();
-                KitchenOrder::where('orderable_type', 'order')->where('orderable_id', $orderID)->delete();
+                KitchenService::clearForInvoice('order', [$orderID]);
             }
             if(!$orderID) {
                 $orderIds = Order::where('table_id', $request->get('table_id'))->pluck('id')->toArray();
                 Order::where('table_id', $request->get('table_id'))->delete();
-                if (!empty($orderIds)) {
-                    KitchenOrder::where('orderable_type', 'order')->whereIn('orderable_id', $orderIds)->delete();
-                }
+                KitchenService::clearForInvoice('order', $orderIds);
             }
             if($invoice->status !== Invoice::STATUS_REFUNDED) {
                 SalesService::parseAndSaveOrder($request->get('order'), $invoice);

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -29,12 +29,29 @@ class KitchenController extends Controller
     /**
      * Mark a kitchen order as ready.
      *
+     * An order whose bill was already cashed out never reaches "Izdate" —
+     * nothing would clear it from there — so it is removed right away.
+     *
      * @param int $id
-     * @return KitchenOrderResource
+     * @return KitchenOrderResource|\Illuminate\Http\JsonResponse
      */
     public function markReady($id)
     {
         $kitchenOrder = KitchenOrder::findOrFail($id);
+
+        if ($kitchenOrder->isInvoiced()) {
+            $kitchenOrder->items()->delete();
+            $kitchenOrder->delete();
+
+            try {
+                app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
+            } catch (\Exception $e) {
+                \Log::error($e->getMessage());
+            }
+
+            return response()->json(['deleted' => true]);
+        }
+
         $kitchenOrder->update(['ready_at' => now()]);
         $kitchenOrder->load('items');
 

--- a/app/Http/Controllers/ThirdPartyInvoiceController.php
+++ b/app/Http/Controllers/ThirdPartyInvoiceController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Inventory;
 use App\Models\Sales;
-use App\Models\KitchenOrder;
 use App\Models\ThirdPartyInvoice;
 use App\Models\ThirdPartyOrder;
 use App\Models\WarehouseStatus;
@@ -13,6 +12,7 @@ use App\Http\Resources\ThirdPartyInvoiceResource;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Services\KitchenService;
 use Services\Pusher;
 use Services\SalesService;
 use Services\WorkingDay;
@@ -426,10 +426,7 @@ class ThirdPartyInvoiceController extends Controller
                 } elseif ($tableId) {
                     $tpoIds = ThirdPartyOrder::where('table_id', $tableId)->pluck('id')->toArray();
                     $ordersDeleted = ThirdPartyOrder::deleteByTableId($tableId);
-                    if (!empty($tpoIds)) {
-                        KitchenOrder::where('orderable_type', 'third_party_order')
-                            ->whereIn('orderable_id', $tpoIds)->delete();
-                    }
+                    KitchenService::clearForInvoice('third_party_order', $tpoIds);
                 }
 
                 return $invoice;

--- a/app/Http/Resources/KitchenOrderResource.php
+++ b/app/Http/Resources/KitchenOrderResource.php
@@ -30,6 +30,7 @@ class KitchenOrderResource extends JsonResource
                 'category_id' => $item->category_id,
             ]),
             'ready_at' => $this->ready_at,
+            'invoiced_at' => $this->invoiced_at,
             'created_at' => $this->created_at,
         ];
     }

--- a/app/Models/KitchenOrder.php
+++ b/app/Models/KitchenOrder.php
@@ -12,10 +12,12 @@ class KitchenOrder extends Model
         'table_name',
         'waiter_name',
         'ready_at',
+        'invoiced_at',
     ];
 
     protected $casts = [
         'ready_at' => 'datetime',
+        'invoiced_at' => 'datetime',
     ];
 
     public function items()
@@ -37,5 +39,15 @@ class KitchenOrder extends Model
     public function scopeReady($query)
     {
         return $query->whereNotNull('ready_at');
+    }
+
+    /**
+     * The bill for this order has already been cashed out. Such an order is
+     * deleted the moment the kitchen marks it ready instead of moving to
+     * "Izdate", because nothing would ever clear it from there.
+     */
+    public function isInvoiced(): bool
+    {
+        return $this->invoiced_at !== null;
     }
 }

--- a/app/Models/ThirdPartyOrder.php
+++ b/app/Models/ThirdPartyOrder.php
@@ -90,8 +90,20 @@ class ThirdPartyOrder extends Model
             return 0;
         }
 
-        // 2. Delete the specific kitchen order items
-        KitchenOrderItem::whereIn('external_item_id', $externalItemIds)->delete();
+        // 2. Delete the specific kitchen order items, but only for orders the
+        //    kitchen already handed out. Food still being prepared stays on the
+        //    display even though the bill was just paid.
+        $readyKitchenOrderIds = KitchenOrder::where('orderable_type', 'third_party_order')
+            ->whereIn('orderable_id', $affectedOrderIds)
+            ->ready()
+            ->pluck('id')
+            ->toArray();
+
+        if (!empty($readyKitchenOrderIds)) {
+            KitchenOrderItem::whereIn('kitchen_order_id', $readyKitchenOrderIds)
+                ->whereIn('external_item_id', $externalItemIds)
+                ->delete();
+        }
 
         // 3. Delete the specific third-party order items
         ThirdPartyOrderItem::whereIn('external_item_id', $externalItemIds)->delete();
@@ -102,17 +114,27 @@ class ThirdPartyOrder extends Model
             $order = static::find($orderId);
             if (!$order) continue;
 
+            $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
+                ->where('orderable_id', $orderId)
+                ->first();
+
             if ($order->items()->count() === 0) {
-                KitchenOrder::where('orderable_type', 'third_party_order')
-                    ->where('orderable_id', $orderId)
-                    ->delete();
+                // Whole order paid: drop the kitchen order if it was already
+                // handed out, otherwise let the kitchen finish it and mark it
+                // as invoiced so it disappears the moment they do.
+                if ($kitchenOrder) {
+                    if ($kitchenOrder->ready_at !== null) {
+                        $kitchenOrder->items()->delete();
+                        $kitchenOrder->delete();
+                    } elseif ($kitchenOrder->invoiced_at === null) {
+                        $kitchenOrder->update(['invoiced_at' => now()]);
+                    }
+                }
                 $order->delete();
                 $ordersDeleted++;
             } else {
-                // Order still has items — clean up kitchen order if no kitchen items remain
-                $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
-                    ->where('orderable_id', $orderId)
-                    ->first();
+                // Order still has un-invoiced items — clean up the kitchen order
+                // only if it ran out of kitchen items
                 if ($kitchenOrder && $kitchenOrder->items()->count() === 0) {
                     $kitchenOrder->delete();
                 }

--- a/database/migrations/2026_07_28_100000_add_invoiced_at_to_kitchen_orders_table.php
+++ b/database/migrations/2026_07_28_100000_add_invoiced_at_to_kitchen_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('kitchen_orders', function (Blueprint $table) {
+            $table->timestamp('invoiced_at')->nullable()->after('ready_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('kitchen_orders', function (Blueprint $table) {
+            $table->dropColumn('invoiced_at');
+        });
+    }
+};

--- a/resources/js/components/Kitchen/KitchenOrderCard.vue
+++ b/resources/js/components/Kitchen/KitchenOrderCard.vue
@@ -14,7 +14,15 @@
         class="absolute inset-0 bg-white/20"
         :style="{ width: fillWidth, transition: 'width 3s linear' }"
       ></div>
-      <span class="relative text-white font-bold text-lg">{{ order.table_name }}</span>
+      <div class="relative flex items-center gap-2">
+        <span class="text-white font-bold text-lg">{{ order.table_name }}</span>
+        <span
+          v-if="order.invoiced_at && mode === 'active'"
+          class="inline-flex items-center px-2 py-0.5 rounded bg-yellow-400 text-gray-900 text-xs font-bold tracking-wide"
+        >
+          PLAĆENO
+        </span>
+      </div>
       <span v-if="order.waiter_name" class="relative text-white font-normal text-lg">{{ order.waiter_name }}</span>
       <template v-if="mode === 'active'">
         <button

--- a/services/KitchenService.php
+++ b/services/KitchenService.php
@@ -107,6 +107,40 @@ class KitchenService
     }
 
     /**
+     * Clear kitchen orders whose bill was just cashed out.
+     *
+     * Orders already handed out ("Izdate") are deleted. Orders the kitchen is
+     * still preparing stay on the display and are only stamped as invoiced —
+     * they disappear once the kitchen marks them ready.
+     *
+     * @param string $orderableType 'order' or 'third_party_order'
+     * @param array $orderableIds
+     * @return void
+     */
+    public static function clearForInvoice(string $orderableType, array $orderableIds): void
+    {
+        if (empty($orderableIds)) {
+            return;
+        }
+
+        $readyKitchenOrders = KitchenOrder::where('orderable_type', $orderableType)
+            ->whereIn('orderable_id', $orderableIds)
+            ->ready()
+            ->get();
+
+        foreach ($readyKitchenOrders as $readyKitchenOrder) {
+            $readyKitchenOrder->items()->delete();
+            $readyKitchenOrder->delete();
+        }
+
+        KitchenOrder::where('orderable_type', $orderableType)
+            ->whereIn('orderable_id', $orderableIds)
+            ->active()
+            ->whereNull('invoiced_at')
+            ->update(['invoiced_at' => now()]);
+    }
+
+    /**
      * Process a POS order and create/update a kitchen order for kitchen items.
      *
      * @param Order $order

--- a/tests/Feature/KitchenOrderTest.php
+++ b/tests/Feature/KitchenOrderTest.php
@@ -4,12 +4,14 @@ namespace Tests\Feature;
 
 use App\Models\Category;
 use App\Models\Inventory;
+use App\Models\Invoice;
 use App\Models\KitchenOrder;
 use App\Models\KitchenOrderItem;
 use App\Models\Order;
 use App\Models\Table;
 use App\Models\ThirdPartyOrder;
 use App\Models\ThirdPartyOrderItem;
+use App\Models\User;
 use App\Http\Middleware\VerifyExternalApiKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -55,6 +57,90 @@ class KitchenOrderTest extends TestCase
 
         $kitchenOrder->refresh();
         $this->assertNotNull($kitchenOrder->ready_at);
+    }
+
+    /**
+     * An order whose bill was already paid is removed when the kitchen marks it
+     * ready — it must never land in "Izdate", because nothing clears it there.
+     */
+    public function test_invoiced_kitchen_order_is_deleted_on_mark_ready()
+    {
+        $kitchenOrder = $this->createKitchenOrderWithItems(['invoiced_at' => now()]);
+
+        $response = $this->postJson("/api/kitchen/orders/{$kitchenOrder->id}/ready");
+
+        $response->assertStatus(200);
+        $response->assertJson(['deleted' => true]);
+
+        $this->assertEquals(0, KitchenOrder::count(), 'The paid order should be gone');
+        $this->assertEquals(0, KitchenOrderItem::count(), 'Its items should be gone too');
+
+        $index = $this->getJson('/api/kitchen/orders');
+        $this->assertEmpty($index->json('active'));
+        $this->assertEmpty($index->json('ready'), 'A paid order should never reach "Izdate"');
+    }
+
+    /**
+     * Cashing out a POS table keeps unfinished kitchen orders on the display
+     * (flagged as paid) and clears only the ones already handed out.
+     */
+    public function test_pos_invoice_keeps_active_kitchen_order_and_deletes_ready_one()
+    {
+        $waiter = User::create([
+            'name' => 'Miloš',
+            'username' => 'milos',
+            'password' => bcrypt('secret'),
+        ]);
+        $table = Table::create(['name' => '5', 'area' => 1, 'table_number' => 5]);
+
+        $stillCooking = Order::create(['table_id' => $table->id, 'total' => 500, 'order' => []]);
+        $alreadyServed = Order::create(['table_id' => $table->id, 'total' => 300, 'order' => []]);
+
+        $activeKitchenOrder = $this->createKitchenOrderWithItems([
+            'orderable_id' => $stillCooking->id,
+        ]);
+        $readyKitchenOrder = $this->createKitchenOrderWithItems([
+            'orderable_id' => $alreadyServed->id,
+            'ready_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/invoices', [
+            'user_id' => $waiter->id,
+            'table_id' => $table->id,
+            'total' => 800,
+            'status' => Invoice::STATUS_REFUNDED,
+            'order' => [['name' => 'Cevapi', 'qty' => 2, 'price' => 400]],
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertEquals(0, Order::count(), 'Both POS orders should be cashed out');
+
+        $this->assertNull(
+            KitchenOrder::find($readyKitchenOrder->id),
+            'The order already in "Izdate" should be deleted by the invoice'
+        );
+        $this->assertNotNull(
+            KitchenOrder::find($activeKitchenOrder->id),
+            'The order the kitchen is still preparing should stay on the display'
+        );
+        $this->assertNotNull(
+            $activeKitchenOrder->fresh()->invoiced_at,
+            'It should be flagged as invoiced so it disappears once marked ready'
+        );
+    }
+
+    /**
+     * The kitchen display exposes invoiced_at so a paid order can be marked.
+     */
+    public function test_invoiced_at_is_returned_in_index()
+    {
+        $this->createKitchenOrderWithItems(['invoiced_at' => now()]);
+
+        $response = $this->getJson('/api/kitchen/orders');
+
+        $response->assertStatus(200);
+        $this->assertNotNull($response->json('active.0.invoiced_at'));
     }
 
     /**

--- a/tests/Feature/ThirdPartyInvoiceOrderClearingTest.php
+++ b/tests/Feature/ThirdPartyInvoiceOrderClearingTest.php
@@ -204,9 +204,10 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
     }
 
     /**
-     * Test that deleteByExternalItemIds also deletes matching KitchenOrderItems.
+     * An active (not yet handed out) kitchen order keeps all of its items when
+     * the bill is paid — the kitchen still has to prepare that food.
      */
-    public function test_deleteByExternalItemIds_deletes_kitchen_order_items()
+    public function test_deleteByExternalItemIds_keeps_kitchen_items_of_active_orders()
     {
         $order = ThirdPartyOrder::create([
             'external_order_id' => 104130,
@@ -284,6 +285,61 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
         ThirdPartyOrder::deleteByExternalItemIds([326984, 326998]);
 
         $this->assertEquals(
+            3,
+            KitchenOrderItem::count(),
+            'All kitchen items stay on the display — the kitchen has not handed this order out yet'
+        );
+        $this->assertNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'Order 327010 is still un-invoiced, so the kitchen order is not flagged as paid yet'
+        );
+    }
+
+    /**
+     * A kitchen order already handed out ("Izdate") is cleaned up as before.
+     */
+    public function test_deleteByExternalItemIds_deletes_kitchen_order_items_when_ready()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 104130,
+            'table_id' => 2,
+            'table_name' => '2',
+            'total' => 630,
+        ]);
+
+        foreach ([326984, 326998, 327010] as $externalItemId) {
+            ThirdPartyOrderItem::create([
+                'third_party_order_id' => $order->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'price' => 210,
+                'unit' => 'kom',
+                'active' => 1,
+            ]);
+        }
+
+        $kitchenOrder = KitchenOrder::create([
+            'orderable_type' => 'third_party_order',
+            'orderable_id' => $order->id,
+            'table_name' => 'Sala 2',
+            'ready_at' => now(),
+        ]);
+
+        foreach ([326984, 326998, 327010] as $externalItemId) {
+            KitchenOrderItem::create([
+                'kitchen_order_id' => $kitchenOrder->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'storno' => false,
+                'is_done' => false,
+            ]);
+        }
+
+        ThirdPartyOrder::deleteByExternalItemIds([326984, 326998]);
+
+        $this->assertEquals(
             1,
             KitchenOrderItem::count(),
             'Only the kitchen item for 327010 should remain after deleting items 326984 and 326998'
@@ -295,9 +351,10 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
     }
 
     /**
-     * Test full cascade: items deleted -> order empty -> kitchen order also deleted.
+     * Whole order paid while the kitchen is still preparing it: the kitchen
+     * order survives, flagged as invoiced, so the food still gets made.
      */
-    public function test_deleteByExternalItemIds_deletes_kitchen_order_when_order_empty()
+    public function test_deleteByExternalItemIds_flags_active_kitchen_order_when_order_empty()
     {
         $order = ThirdPartyOrder::create([
             'external_order_id' => 104130,
@@ -361,14 +418,76 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
             'ThirdPartyOrder should be soft-deleted when all items are removed'
         );
         $this->assertEquals(
+            1,
+            KitchenOrder::count(),
+            'KitchenOrder should stay on the display — the kitchen has not handed it out yet'
+        );
+        $this->assertEquals(
+            2,
+            KitchenOrderItem::count(),
+            'Kitchen items stay so the kitchen still knows what to prepare'
+        );
+        $this->assertNotNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'KitchenOrder should be flagged as invoiced so it disappears once marked ready'
+        );
+    }
+
+    /**
+     * Same scenario, but the kitchen already handed the order out: it is
+     * deleted at invoice time, as before.
+     */
+    public function test_deleteByExternalItemIds_deletes_ready_kitchen_order_when_order_empty()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 104130,
+            'table_id' => 2,
+            'table_name' => '2',
+            'total' => 420,
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            ThirdPartyOrderItem::create([
+                'third_party_order_id' => $order->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'price' => 210,
+                'unit' => 'kom',
+                'active' => 1,
+            ]);
+        }
+
+        $kitchenOrder = KitchenOrder::create([
+            'orderable_type' => 'third_party_order',
+            'orderable_id' => $order->id,
+            'table_name' => 'Sala 2',
+            'ready_at' => now(),
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            KitchenOrderItem::create([
+                'kitchen_order_id' => $kitchenOrder->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'storno' => false,
+                'is_done' => false,
+            ]);
+        }
+
+        $deleted = ThirdPartyOrder::deleteByExternalItemIds([326984, 326998]);
+
+        $this->assertEquals(1, $deleted, 'Should delete 1 order');
+        $this->assertEquals(
             0,
             KitchenOrder::count(),
-            'KitchenOrder should be deleted when its parent order has no items left'
+            'A kitchen order already in "Izdate" should be deleted when its parent order is paid'
         );
         $this->assertEquals(
             0,
             KitchenOrderItem::count(),
-            'KitchenOrderItems should be deleted along with their kitchen order items'
+            'Its items should go with it'
         );
     }
 
@@ -460,9 +579,13 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
             'Kitchen order should persist because the parent order still has items'
         );
         $this->assertEquals(
-            1,
+            3,
             KitchenOrderItem::count(),
-            'Only kitchen item 327010 should remain'
+            'Kitchen items are untouched while the order is still being prepared'
+        );
+        $this->assertNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'A partially invoiced order is not flagged as paid'
         );
     }
 
@@ -1414,9 +1537,10 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
     // =========================================================================
 
     /**
-     * Test that kitchen orders are cleared when an invoice clears all items.
+     * An invoice clearing all items keeps an unfinished kitchen order on the
+     * display and flags it as paid.
      */
-    public function test_kitchen_orders_cleared_when_invoice_clears_all_items()
+    public function test_active_kitchen_order_survives_invoice_and_is_flagged()
     {
         $order = ThirdPartyOrder::create([
             'external_order_id' => 104130,
@@ -1495,21 +1619,107 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
         $response->assertStatus(201);
 
         $this->assertEquals(
+            1,
+            KitchenOrder::count(),
+            'Kitchen order should stay on the display so the kitchen can finish it'
+        );
+        $this->assertEquals(
+            2,
+            KitchenOrderItem::count(),
+            'Kitchen order items should stay with it'
+        );
+        $this->assertNotNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'Kitchen order should be flagged as invoiced'
+        );
+
+        // Marking it ready now removes it instead of moving it to "Izdate"
+        $this->postJson("/api/kitchen/orders/{$kitchenOrder->id}/ready")->assertStatus(200);
+
+        $this->assertEquals(0, KitchenOrder::count(), 'Paid order should disappear when marked ready');
+        $this->assertEquals(0, KitchenOrderItem::count(), 'Its items should go with it');
+    }
+
+    /**
+     * A kitchen order already handed out is deleted by the invoice, as before.
+     */
+    public function test_ready_kitchen_order_is_deleted_by_invoice()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 104130,
+            'table_id' => 2,
+            'table_name' => '2',
+            'total' => 420,
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            ThirdPartyOrderItem::create([
+                'third_party_order_id' => $order->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'price' => 210,
+                'unit' => 'kom',
+                'active' => 1,
+            ]);
+        }
+
+        $kitchenOrder = KitchenOrder::create([
+            'orderable_type' => 'third_party_order',
+            'orderable_id' => $order->id,
+            'table_name' => 'Sala 2',
+            'ready_at' => now(),
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            KitchenOrderItem::create([
+                'kitchen_order_id' => $kitchenOrder->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'storno' => false,
+                'is_done' => false,
+            ]);
+        }
+
+        $response = $this->postJson('/api/third-party-invoice', [
+            [
+                'kolicina' => 2,
+                'cena' => 210,
+                'naziv' => 'Drinks',
+                'jm' => 'kom',
+                'gotovina' => 420,
+                'kartica' => 0,
+                'prenosnaracun' => 0,
+                'datum' => '2026-02-23 22:01:10',
+                'brojracuna' => 29926,
+                'sto' => '2',
+                'stoid' => 2,
+                'racunid' => 42949,
+                'stornirano' => 0,
+                'listastavki' => '326984, 326998',
+            ],
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertEquals(
             0,
             KitchenOrder::count(),
-            'Kitchen order should be deleted when all its items are cleared via invoice'
+            'Kitchen order already in "Izdate" should be deleted when the bill is paid'
         );
         $this->assertEquals(
             0,
             KitchenOrderItem::count(),
-            'Kitchen order items should be deleted when cleared via invoice listastavki'
+            'Kitchen order items should be deleted with it'
         );
     }
 
     /**
-     * Test that the kitchen display API excludes cleared orders after invoice processing.
+     * The kitchen display keeps listing an unfinished order after its bill is
+     * paid, and drops it the moment the kitchen marks it ready.
      */
-    public function test_kitchen_display_api_excludes_cleared_orders()
+    public function test_kitchen_display_api_keeps_active_order_after_invoice()
     {
         // Create order and kitchen order
         $order = ThirdPartyOrder::create([
@@ -1572,14 +1782,27 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
 
         $response->assertStatus(201);
 
-        // Verify kitchen order is gone from the API
+        // The order is still being prepared, so it stays in the active list
         $kitchenResponse = $this->getJson('/api/kitchen/orders');
         $kitchenResponse->assertStatus(200);
         $activeOrders = $kitchenResponse->json('active');
-        $this->assertEmpty(
+        $this->assertCount(
+            1,
             $activeOrders,
-            'Kitchen order should NOT appear in active list after invoice cleared its items'
+            'Kitchen order should still appear in the active list after its bill was paid'
         );
+        $this->assertNotNull(
+            $activeOrders[0]['invoiced_at'],
+            'The API should expose invoiced_at so the display can mark it as paid'
+        );
+
+        // Once the kitchen marks it ready it disappears instead of moving to "Izdate"
+        $this->postJson("/api/kitchen/orders/{$kitchenOrder->id}/ready")->assertStatus(200);
+
+        $kitchenResponse = $this->getJson('/api/kitchen/orders');
+        $kitchenResponse->assertStatus(200);
+        $this->assertEmpty($kitchenResponse->json('active'), 'Should be gone from active');
+        $this->assertEmpty($kitchenResponse->json('ready'), 'Should never reach "Izdate"');
     }
 
     // =========================================================================


### PR DESCRIPTION
Cashing out a table deleted every kitchen order for it, including food
the kitchen had not finished yet — it vanished from "Aktivne" mid-prep.

Now invoicing only deletes kitchen orders already handed out ("Izdate").
Ones still being prepared stay on the display and are stamped with the
new kitchen_orders.invoiced_at. Marking such an order ready deletes it
right away instead of moving it to "Izdate", where nothing would ever
clear it since the bill is already settled. The card shows a PLAĆENO
chip so the kitchen knows that step is final.

Partial invoices (ebar item-level clearing) leave the kitchen order
untouched — it is only flagged once its parent order is fully paid, so
un-invoiced food can never disappear with it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ke9z1tgtnTuEMDGqebKbYy