### PR TITLE
Keep unfinished kitchen orders after cash-out + survive all-tables order sync

### DIFF
--- a/app/Console/Commands/CleanupKitchenOrders.php
+++ b/app/Console/Commands/CleanupKitchenOrders.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use App\Models\KitchenOrder;
 use App\Models\KitchenOrderItem;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class CleanupKitchenOrders extends Command
 {
@@ -17,10 +17,10 @@ class CleanupKitchenOrders extends Command
     {
         $count = KitchenOrder::count();
 
-        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        Schema::disableForeignKeyConstraints();
         KitchenOrderItem::truncate();
         KitchenOrder::truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        Schema::enableForeignKeyConstraints();
 
         $this->info("Deleted {$count} kitchen orders.");
 

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -9,9 +9,9 @@ use Services\Pusher;
 use App\Models\Order;
 use App\Models\Sales;
 use App\Models\Invoice;
-use App\Models\KitchenOrder;
 use Services\WorkingDay;
 use Services\SalesService;
+use Services\KitchenService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -56,14 +56,12 @@ class InvoiceController extends Controller
         if ($invoice) {
             if($orderID) {
                 Order::where('id', $orderID)->delete();
-                KitchenOrder::where('orderable_type', 'order')->where('orderable_id', $orderID)->delete();
+                KitchenService::clearForInvoice('order', [$orderID]);
             }
             if(!$orderID) {
                 $orderIds = Order::where('table_id', $request->get('table_id'))->pluck('id')->toArray();
                 Order::where('table_id', $request->get('table_id'))->delete();
-                if (!empty($orderIds)) {
-                    KitchenOrder::where('orderable_type', 'order')->whereIn('orderable_id', $orderIds)->delete();
-                }
+                KitchenService::clearForInvoice('order', $orderIds);
             }
             if($invoice->status !== Invoice::STATUS_REFUNDED) {
                 SalesService::parseAndSaveOrder($request->get('order'), $invoice);

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -29,12 +29,29 @@ class KitchenController extends Controller
     /**
      * Mark a kitchen order as ready.
      *
+     * An order whose bill was already cashed out never reaches "Izdate" —
+     * nothing would clear it from there — so it is removed right away.
+     *
      * @param int $id
-     * @return KitchenOrderResource
+     * @return KitchenOrderResource|\Illuminate\Http\JsonResponse
      */
     public function markReady($id)
     {
         $kitchenOrder = KitchenOrder::findOrFail($id);
+
+        if ($kitchenOrder->isInvoiced()) {
+            $kitchenOrder->items()->delete();
+            $kitchenOrder->delete();
+
+            try {
+                app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
+            } catch (\Exception $e) {
+                \Log::error($e->getMessage());
+            }
+
+            return response()->json(['deleted' => true]);
+        }
+
         $kitchenOrder->update(['ready_at' => now()]);
         $kitchenOrder->load('items');
 

--- a/app/Http/Controllers/ThirdPartyInvoiceController.php
+++ b/app/Http/Controllers/ThirdPartyInvoiceController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Inventory;
 use App\Models\Sales;
-use App\Models\KitchenOrder;
 use App\Models\ThirdPartyInvoice;
 use App\Models\ThirdPartyOrder;
 use App\Models\WarehouseStatus;
@@ -13,6 +12,7 @@ use App\Http\Resources\ThirdPartyInvoiceResource;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Services\KitchenService;
 use Services\Pusher;
 use Services\SalesService;
 use Services\WorkingDay;
@@ -426,10 +426,7 @@ class ThirdPartyInvoiceController extends Controller
                 } elseif ($tableId) {
                     $tpoIds = ThirdPartyOrder::where('table_id', $tableId)->pluck('id')->toArray();
                     $ordersDeleted = ThirdPartyOrder::deleteByTableId($tableId);
-                    if (!empty($tpoIds)) {
-                        KitchenOrder::where('orderable_type', 'third_party_order')
-                            ->whereIn('orderable_id', $tpoIds)->delete();
-                    }
+                    KitchenService::clearForInvoice('third_party_order', $tpoIds);
                 }
 
                 return $invoice;

--- a/app/Http/Controllers/ThirdPartyOrderController.php
+++ b/app/Http/Controllers/ThirdPartyOrderController.php
@@ -186,7 +186,11 @@ class ThirdPartyOrderController extends Controller
             }
         }
 
-        $allFailed = !empty($summary['failed']) && empty($processedOrders) && empty($summary['skipped_invoiced']);
+        // Any failed group means a non-2xx, matching the old all-or-nothing
+        // contract so a retrying client resends (resends are idempotent, so
+        // the already-committed groups are no-ops and the failed one gets
+        // another chance).
+        $anyFailed = !empty($summary['failed']);
 
         Log::info('[ThirdPartyOrder] Orders processed', [
             'summary' => array_merge($summary, [
@@ -196,15 +200,15 @@ class ThirdPartyOrderController extends Controller
         ]);
 
         return response()->json([
-            'success' => !$allFailed,
-            'message' => $allFailed
-                ? 'Failed to process orders'
+            'success' => !$anyFailed,
+            'message' => $anyFailed
+                ? count($processedOrders) . ' order(s) processed, ' . count($summary['failed']) . ' failed'
                 : count($processedOrders) . ' order(s) processed',
             'data' => ThirdPartyOrderResource::collection(
-                collect($processedOrders)->map->load('items')
+                (new \Illuminate\Database\Eloquent\Collection($processedOrders))->load('items')
             ),
             'summary' => $summary,
-        ], $allFailed ? 500 : 201);
+        ], $anyFailed ? 500 : 201);
     }
 
     /**
@@ -283,9 +287,15 @@ class ThirdPartyOrderController extends Controller
             $existingItem = $existingItems->get($externalItemId);
 
             if ($existingItem && $existingItem->trashed()) {
-                // Already paid via a partial invoice — stays out of the order
-                // and out of the total.
-                continue;
+                if ($existingItem->invoiced_at !== null) {
+                    // Already paid via a partial invoice — stays out of the
+                    // order and out of the total.
+                    continue;
+                }
+
+                // Pruned by an earlier sync (removed from the order) and now
+                // re-added with the same stavkaid: bring it back.
+                $existingItem->restore();
             }
 
             $qty = (float) ($row['kolicina'] ?? 0);

--- a/app/Http/Controllers/ThirdPartyOrderController.php
+++ b/app/Http/Controllers/ThirdPartyOrderController.php
@@ -2,16 +2,34 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ThirdPartyInvoice;
 use App\Models\ThirdPartyOrder;
 use App\Models\ThirdPartyOrderItem;
 use App\Http\Requests\ThirdPartyOrderStoreRequest;
 use App\Http\Resources\ThirdPartyOrderResource;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Services\KitchenService;
 use Services\Pusher;
+use Services\WorkingDay;
 
 class ThirdPartyOrderController extends Controller
 {
+    /**
+     * Upper bound on rows per request. An all-tables startup sync from the
+     * external system is ~600 rows; this only guards against runaway payloads.
+     */
+    public const MAX_ROWS = 5000;
+
+    /**
+     * Payloads up to this many rows are logged in full for debugging;
+     * larger ones (startup syncs) are logged as a summary.
+     */
+    private const LOG_FULL_BODY_MAX_ROWS = 50;
+
     /**
      * Get all active third-party orders.
      *
@@ -35,10 +53,18 @@ class ThirdPartyOrderController extends Controller
     {
         $rows = $request->all();
 
-        Log::info('[ThirdPartyOrder] Incoming request', [
-            'body' => $rows,
-            'ip' => $request->ip(),
-        ]);
+        if (count($rows) <= self::LOG_FULL_BODY_MAX_ROWS) {
+            Log::info('[ThirdPartyOrder] Incoming request', [
+                'body' => $rows,
+                'ip' => $request->ip(),
+            ]);
+        } else {
+            Log::info('[ThirdPartyOrder] Incoming request (large payload)', [
+                'rows' => count($rows),
+                'order_ids' => collect($rows)->pluck('porudzbinaid')->unique()->values()->toArray(),
+                'ip' => $request->ip(),
+            ]);
+        }
 
         if (empty($rows)) {
             Log::warning('[ThirdPartyOrder] Empty data provided', [
@@ -50,132 +76,291 @@ class ThirdPartyOrderController extends Controller
             ], 422);
         }
 
+        if (count($rows) > self::MAX_ROWS) {
+            Log::warning('[ThirdPartyOrder] Payload too large', [
+                'rows' => count($rows),
+                'ip' => $request->ip(),
+            ]);
+            return response()->json([
+                'success' => false,
+                'message' => 'Too many rows in one request (max ' . self::MAX_ROWS . ')',
+            ], 422);
+        }
+
+        // A retry after a timeout must not interleave with the still-running
+        // first request; process one sync at a time.
         try {
-            // Group rows by porudzbinaid (multiple orders can be in one request)
-            $orderGroups = collect($rows)->groupBy('porudzbinaid');
-            $processedOrders = [];
+            return Cache::lock('third-party-order-store', 60)
+                ->block(10, fn () => $this->processOrderRows($rows));
+        } catch (LockTimeoutException $e) {
+            Log::warning('[ThirdPartyOrder] Another sync is still running', [
+                'ip' => $request->ip(),
+            ]);
+            return response()->json([
+                'success' => false,
+                'message' => 'Another order sync is still being processed, retry shortly',
+            ], 429);
+        }
+    }
 
-            foreach ($orderGroups as $externalOrderId => $orderRows) {
-                $orderRows = self::mergeModifierRows($orderRows);
-                $firstRow = $orderRows->first();
+    /**
+     * Process the grouped order rows, each order in its own transaction so
+     * one bad group cannot take down the rest of a multi-table payload.
+     *
+     * @param array $rows
+     * @return \Illuminate\Http\JsonResponse
+     */
+    private function processOrderRows(array $rows)
+    {
+        // Split invalid rows out before grouping so they cannot collapse into
+        // a bogus order 0 and overwrite each other's items.
+        [$validRows, $invalidRows] = collect($rows)->partition(function ($row) {
+            return is_array($row)
+                && isset($row['porudzbinaid'])
+                && is_numeric($row['porudzbinaid'])
+                && (int) $row['porudzbinaid'] > 0;
+        });
 
-                // Extract order-level data (lowercase field names)
-                $tableId = isset($firstRow['stoid']) ? (int) $firstRow['stoid'] : null;
-                $tableName = (string) ($firstRow['sto'] ?? 'Unknown');
-                $lastRow = $orderRows->last();
-                $waiterName = $lastRow['konobar'] ?? null;
+        if ($invalidRows->isNotEmpty()) {
+            Log::warning('[ThirdPartyOrder] Skipped rows with missing/invalid porudzbinaid', [
+                'count' => $invalidRows->count(),
+                'sample' => $invalidRows->first(),
+            ]);
+        }
 
-                // Parse order datetime from datum field
-                $orderedAt = isset($firstRow['datum']) && !empty($firstRow['datum'])
-                    ? $firstRow['datum']
-                    : null;
+        // Group rows by porudzbinaid (multiple orders can be in one request)
+        $orderGroups = $validRows->groupBy('porudzbinaid');
+        $processedOrders = [];
+        $summary = [
+            'processed' => 0,
+            'created' => 0,
+            'updated' => 0,
+            'skipped_invoiced' => [],
+            'invalid_rows' => $invalidRows->count(),
+            'failed' => [],
+        ];
 
-                // Find or create order
-                $order = ThirdPartyOrder::updateOrCreate(
-                    ['external_order_id' => (int) $externalOrderId],
-                    [
-                        'table_id' => $tableId,
-                        'table_name' => $tableName,
-                        'total' => 0,
-                        'ordered_at' => $orderedAt,
-                    ]
-                );
+        if ($orderGroups->isEmpty()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No valid rows provided',
+                'summary' => $summary,
+            ], 422);
+        }
 
-                $totalCents = 0;
-                $incomingItemIds = [];
+        foreach ($orderGroups as $externalOrderId => $orderRows) {
+            $externalOrderId = (int) $externalOrderId;
 
-                foreach ($orderRows as $row) {
-                    $externalItemId = (int) ($row['stavkaid'] ?? 0);
-                    $qty = (float) ($row['kolicina'] ?? 0);
-                    $price = (int) round((float) ($row['cena'] ?? 0));
-                    $itemTotal = (int) round($qty * $price);
-                    $totalCents += $itemTotal;
+            try {
+                $order = DB::transaction(function () use ($externalOrderId, $orderRows, &$summary) {
+                    return $this->processOrderGroup($externalOrderId, $orderRows, $summary);
+                });
 
-                    $incomingItemIds[] = $externalItemId;
-
-                    // Find existing item to preserve active flag
-                    $existingItem = $order->items()
-                        ->where('external_item_id', $externalItemId)
-                        ->first();
-
-                    $itemData = [
-                        'third_party_order_id' => $order->id,
-                        'external_item_id' => $externalItemId,
-                        'name' => (string) ($row['naziv'] ?? 'Unknown'),
-                        'qty' => $qty,
-                        'price' => $price,
-                        'unit' => (string) ($row['jm'] ?? 'kom'),
-                        'modifier' => $row['modifikatorslobodan'] ?? null,
-                        'sku' => $row['sifraArtikla'] ?? null,
-                        'print_station_id' => isset($row['stampanjenalogaid']) ? (int) $row['stampanjenalogaid'] : null,
-                    ];
-
-                    if ($existingItem) {
-                        // Update existing item - DO NOT touch active flag
-                        $existingItem->update($itemData);
-                    } else {
-                        // New item - default active = 1
-                        $itemData['active'] = 1;
-                        ThirdPartyOrderItem::create($itemData);
-                    }
+                if ($order !== null) {
+                    $processedOrders[] = $order;
+                    $summary['processed']++;
+                    $order->wasRecentlyCreated ? $summary['created']++ : $summary['updated']++;
                 }
-
-                // Remove items no longer in this order
-                $order->items()
-                    ->whereNotIn('external_item_id', $incomingItemIds)
-                    ->delete();
-
-                // Update order total
-                $order->update(['total' => $totalCents]);
-
-                $wasPreviouslyInvoiced = ThirdPartyOrder::onlyTrashed()
-                    ->where('external_order_id', (int) $externalOrderId)
-                    ->exists();
-
-                if (!$wasPreviouslyInvoiced) {
-                    try {
-                        \Services\KitchenService::processThirdPartyOrder($order, $waiterName);
-                    } catch (\Exception $e) {
-                        Log::error('[Kitchen] ' . $e->getMessage());
-                    }
-                }
-
-                $processedOrders[] = $order;
+            } catch (\Exception $e) {
+                Log::error('[ThirdPartyOrder] Failed to process order group', [
+                    'external_order_id' => $externalOrderId,
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+                $summary['failed'][] = [
+                    'external_order_id' => $externalOrderId,
+                    'error' => $e->getMessage(),
+                ];
             }
+        }
 
-            // Notify backoffice of update
+        // One broadcast per request, not one per order
+        if (!empty($processedOrders)) {
             try {
                 app(Pusher::class)->trigger('broadcasting', 'tables-update', []);
+                app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
             } catch (\Exception $e) {
                 Log::error('[ThirdPartyOrder] Pusher notification failed', [
                     'error' => $e->getMessage(),
                 ]);
             }
-
-            Log::info('[ThirdPartyOrder] Orders processed successfully', [
-                'count' => count($processedOrders),
-                'order_ids' => collect($processedOrders)->pluck('external_order_id')->toArray(),
-            ]);
-
-            return response()->json([
-                'success' => true,
-                'message' => count($processedOrders) . ' order(s) processed',
-                'data' => ThirdPartyOrderResource::collection(
-                    collect($processedOrders)->map->load('items')
-                ),
-            ], 201);
-        } catch (\Exception $e) {
-            Log::error('[ThirdPartyOrder] Failed to process orders', [
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-            ]);
-
-            return response()->json([
-                'success' => false,
-                'message' => 'Failed to process orders',
-                'error' => $e->getMessage(),
-            ], 500);
         }
+
+        $allFailed = !empty($summary['failed']) && empty($processedOrders) && empty($summary['skipped_invoiced']);
+
+        Log::info('[ThirdPartyOrder] Orders processed', [
+            'summary' => array_merge($summary, [
+                'failed' => collect($summary['failed'])->pluck('external_order_id')->toArray(),
+            ]),
+            'order_ids' => collect($processedOrders)->pluck('external_order_id')->toArray(),
+        ]);
+
+        return response()->json([
+            'success' => !$allFailed,
+            'message' => $allFailed
+                ? 'Failed to process orders'
+                : count($processedOrders) . ' order(s) processed',
+            'data' => ThirdPartyOrderResource::collection(
+                collect($processedOrders)->map->load('items')
+            ),
+            'summary' => $summary,
+        ], $allFailed ? 500 : 201);
+    }
+
+    /**
+     * Process one porudzbinaid group: resolve the order against soft-deleted
+     * history, sync its items, and dispatch it to the kitchen.
+     *
+     * Returns null when the order was skipped because an invoice already
+     * settled it during the current working day.
+     *
+     * @param int $externalOrderId
+     * @param \Illuminate\Support\Collection $orderRows
+     * @param array $summary
+     * @return ThirdPartyOrder|null
+     */
+    private function processOrderGroup(int $externalOrderId, $orderRows, array &$summary): ?ThirdPartyOrder
+    {
+        $orderRows = self::mergeModifierRows($orderRows);
+        $firstRow = $orderRows->first();
+
+        // Extract order-level data (lowercase field names)
+        $tableId = isset($firstRow['stoid']) ? (int) $firstRow['stoid'] : null;
+        $tableName = (string) ($firstRow['sto'] ?? 'Unknown');
+        $lastRow = $orderRows->last();
+        $waiterName = $lastRow['konobar'] ?? null;
+
+        // Parse order datetime from datum field
+        $orderedAt = isset($firstRow['datum']) && !empty($firstRow['datum'])
+            ? $firstRow['datum']
+            : null;
+
+        $attributes = [
+            'table_id' => $tableId,
+            'table_name' => $tableName,
+            'total' => 0,
+            'ordered_at' => $orderedAt,
+        ];
+
+        $order = ThirdPartyOrder::where('external_order_id', $externalOrderId)->first();
+
+        if ($order) {
+            $order->update($attributes);
+        } else {
+            // No live row. If the last one was closed by an invoice during the
+            // current working day, this is a resend of a paid order — it must
+            // not come back as a ghost table or reach the kitchen. A row
+            // soft-deleted by the 4am cleanup, or from a previous working day
+            // (the external system reuses ids across days), is treated as new.
+            $lastTrashed = ThirdPartyOrder::onlyTrashed()
+                ->where('external_order_id', $externalOrderId)
+                ->orderByDesc('deleted_at')
+                ->first();
+
+            if ($lastTrashed && $this->wasSettledThisWorkingDay($lastTrashed, $externalOrderId)) {
+                Log::warning('[ThirdPartyOrder] Skipping resent order already closed by an invoice', [
+                    'external_order_id' => $externalOrderId,
+                ]);
+                $summary['skipped_invoiced'][] = $externalOrderId;
+                return null;
+            }
+
+            $order = ThirdPartyOrder::create(
+                ['external_order_id' => $externalOrderId] + $attributes
+            );
+        }
+
+        // One lookup for all of this order's items, trashed included: an item
+        // cleared by a partial invoice (listastavki) must not be resurrected
+        // or duplicated when the external system resends the whole order.
+        $existingItems = $order->items()->withTrashed()->get()->keyBy('external_item_id');
+
+        $totalCents = 0;
+        $liveItemIds = [];
+
+        foreach ($orderRows as $row) {
+            $externalItemId = (int) ($row['stavkaid'] ?? 0);
+            $existingItem = $existingItems->get($externalItemId);
+
+            if ($existingItem && $existingItem->trashed()) {
+                // Already paid via a partial invoice — stays out of the order
+                // and out of the total.
+                continue;
+            }
+
+            $qty = (float) ($row['kolicina'] ?? 0);
+            $price = (int) round((float) ($row['cena'] ?? 0));
+            $totalCents += (int) round($qty * $price);
+
+            $liveItemIds[] = $externalItemId;
+
+            $itemData = [
+                'third_party_order_id' => $order->id,
+                'external_item_id' => $externalItemId,
+                'name' => (string) ($row['naziv'] ?? 'Unknown'),
+                'qty' => $qty,
+                'price' => $price,
+                'unit' => (string) ($row['jm'] ?? 'kom'),
+                'modifier' => $row['modifikatorslobodan'] ?? null,
+                'sku' => $row['sifraArtikla'] ?? null,
+                'print_station_id' => isset($row['stampanjenalogaid']) ? (int) $row['stampanjenalogaid'] : null,
+            ];
+
+            if ($existingItem) {
+                // Update existing item - DO NOT touch active flag
+                $existingItem->update($itemData);
+            } else {
+                // New item - default active = 1
+                $itemData['active'] = 1;
+                ThirdPartyOrderItem::create($itemData);
+            }
+        }
+
+        // Remove items no longer in this order
+        $order->items()
+            ->whereNotIn('external_item_id', $liveItemIds)
+            ->delete();
+
+        // Update order total
+        $order->update(['total' => $totalCents]);
+
+        try {
+            KitchenService::processThirdPartyOrder($order, $waiterName, false);
+        } catch (\Exception $e) {
+            Log::error('[Kitchen] ' . $e->getMessage());
+        }
+
+        return $order;
+    }
+
+    /**
+     * Was this soft-deleted order closed by an invoice during the current
+     * working day (4am-4am)? Bounded to the working day because the external
+     * system reuses porudzbinaid on subsequent days — an older invoice says
+     * nothing about today's order.
+     *
+     * @param ThirdPartyOrder $trashedOrder
+     * @param int $externalOrderId
+     * @return bool
+     */
+    private function wasSettledThisWorkingDay(ThirdPartyOrder $trashedOrder, int $externalOrderId): bool
+    {
+        [$dayStart, $dayEnd] = WorkingDay::getWorkingDay();
+
+        // Exact signal: the invoice close paths stamp invoiced_at before
+        // soft-deleting (the 4am cleanup does not).
+        if ($trashedOrder->invoiced_at !== null
+            && $trashedOrder->invoiced_at->between($dayStart, $dayEnd)) {
+            return true;
+        }
+
+        // Retroactive signal for rows trashed before invoiced_at existed. A
+        // stornoed invoice means the payment was cancelled, so it never
+        // suppresses the order.
+        return ThirdPartyInvoice::where('external_order_id', $externalOrderId)
+            ->where('status', '!=', ThirdPartyInvoice::STATUS_STORNO)
+            ->whereBetween('created_at', [$dayStart, $dayEnd])
+            ->exists();
     }
 
     /**
@@ -307,16 +492,19 @@ class ThirdPartyOrderController extends Controller
                 try {
                     $order = ThirdPartyOrder::find($orderId);
                     if ($order) {
-                        \Services\KitchenService::processThirdPartyOrder($order);
+                        KitchenService::processThirdPartyOrder($order, null, false);
                     }
                 } catch (\Exception $e) {
                     Log::error('[Kitchen] ' . $e->getMessage());
                 }
             }
 
-            // Notify backoffice of update
+            // Notify backoffice of update — one broadcast per request
             try {
                 app(Pusher::class)->trigger('broadcasting', 'tables-update', []);
+                if ($affectedOrderIds->isNotEmpty()) {
+                    app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
+                }
             } catch (\Exception $e) {
                 Log::error('[ThirdPartyOrder] Pusher notification failed', [
                     'error' => $e->getMessage(),

--- a/app/Http/Resources/KitchenOrderResource.php
+++ b/app/Http/Resources/KitchenOrderResource.php
@@ -30,6 +30,7 @@ class KitchenOrderResource extends JsonResource
                 'category_id' => $item->category_id,
             ]),
             'ready_at' => $this->ready_at,
+            'invoiced_at' => $this->invoiced_at,
             'created_at' => $this->created_at,
         ];
     }

--- a/app/Models/KitchenOrder.php
+++ b/app/Models/KitchenOrder.php
@@ -12,10 +12,12 @@ class KitchenOrder extends Model
         'table_name',
         'waiter_name',
         'ready_at',
+        'invoiced_at',
     ];
 
     protected $casts = [
         'ready_at' => 'datetime',
+        'invoiced_at' => 'datetime',
     ];
 
     public function items()
@@ -37,5 +39,15 @@ class KitchenOrder extends Model
     public function scopeReady($query)
     {
         return $query->whereNotNull('ready_at');
+    }
+
+    /**
+     * The bill for this order has already been cashed out. Such an order is
+     * deleted the moment the kitchen marks it ready instead of moving to
+     * "Izdate", because nothing would ever clear it from there.
+     */
+    public function isInvoiced(): bool
+    {
+        return $this->invoiced_at !== null;
     }
 }

--- a/app/Models/ThirdPartyInvoice.php
+++ b/app/Models/ThirdPartyInvoice.php
@@ -103,6 +103,18 @@ class ThirdPartyInvoice extends Model
 
             // Delete related sales records
             \App\Models\Sales::where('batch_id', $this->id)->delete();
+
+            // The payment is cancelled, so the order it settled is open again:
+            // clear the invoiced stamp so a resend from the external system is
+            // no longer skipped as "already paid". (A listastavki invoice that
+            // closed several porudzbine only carries this one external id —
+            // same granularity as the storno reference itself.)
+            if ($this->external_order_id) {
+                ThirdPartyOrder::onlyTrashed()
+                    ->where('external_order_id', $this->external_order_id)
+                    ->whereNotNull('invoiced_at')
+                    ->update(['invoiced_at' => null]);
+            }
         });
 
         return true;

--- a/app/Models/ThirdPartyOrder.php
+++ b/app/Models/ThirdPartyOrder.php
@@ -71,6 +71,7 @@ class ThirdPartyOrder extends Model
     public static function deleteByTableId(int $tableId): int
     {
         $orderIds = static::where('table_id', $tableId)->pluck('id');
+        ThirdPartyOrderItem::whereIn('third_party_order_id', $orderIds)->update(['invoiced_at' => now()]);
         ThirdPartyOrderItem::whereIn('third_party_order_id', $orderIds)->delete();
         // Stamp before soft-deleting: a trashed row with invoiced_at set means
         // "closed by an invoice", as opposed to the 4am cleanup.
@@ -111,7 +112,9 @@ class ThirdPartyOrder extends Model
                 ->delete();
         }
 
-        // 3. Delete the specific third-party order items
+        // 3. Delete the specific third-party order items. Stamp them first so a
+        //    resend can tell "paid" apart from "pruned by an earlier sync".
+        ThirdPartyOrderItem::whereIn('external_item_id', $externalItemIds)->update(['invoiced_at' => now()]);
         ThirdPartyOrderItem::whereIn('external_item_id', $externalItemIds)->delete();
 
         // 4. Clean up empty orders and their kitchen orders

--- a/app/Models/ThirdPartyOrder.php
+++ b/app/Models/ThirdPartyOrder.php
@@ -90,8 +90,20 @@ class ThirdPartyOrder extends Model
             return 0;
         }
 
-        // 2. Delete the specific kitchen order items
-        KitchenOrderItem::whereIn('external_item_id', $externalItemIds)->delete();
+        // 2. Delete the specific kitchen order items, but only for orders the
+        //    kitchen already handed out. Food still being prepared stays on the
+        //    display even though the bill was just paid.
+        $readyKitchenOrderIds = KitchenOrder::where('orderable_type', 'third_party_order')
+            ->whereIn('orderable_id', $affectedOrderIds)
+            ->ready()
+            ->pluck('id')
+            ->toArray();
+
+        if (!empty($readyKitchenOrderIds)) {
+            KitchenOrderItem::whereIn('kitchen_order_id', $readyKitchenOrderIds)
+                ->whereIn('external_item_id', $externalItemIds)
+                ->delete();
+        }
 
         // 3. Delete the specific third-party order items
         ThirdPartyOrderItem::whereIn('external_item_id', $externalItemIds)->delete();
@@ -102,17 +114,27 @@ class ThirdPartyOrder extends Model
             $order = static::find($orderId);
             if (!$order) continue;
 
+            $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
+                ->where('orderable_id', $orderId)
+                ->first();
+
             if ($order->items()->count() === 0) {
-                KitchenOrder::where('orderable_type', 'third_party_order')
-                    ->where('orderable_id', $orderId)
-                    ->delete();
+                // Whole order paid: drop the kitchen order if it was already
+                // handed out, otherwise let the kitchen finish it and mark it
+                // as invoiced so it disappears the moment they do.
+                if ($kitchenOrder) {
+                    if ($kitchenOrder->ready_at !== null) {
+                        $kitchenOrder->items()->delete();
+                        $kitchenOrder->delete();
+                    } elseif ($kitchenOrder->invoiced_at === null) {
+                        $kitchenOrder->update(['invoiced_at' => now()]);
+                    }
+                }
                 $order->delete();
                 $ordersDeleted++;
             } else {
-                // Order still has items — clean up kitchen order if no kitchen items remain
-                $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
-                    ->where('orderable_id', $orderId)
-                    ->first();
+                // Order still has un-invoiced items — clean up the kitchen order
+                // only if it ran out of kitchen items
                 if ($kitchenOrder && $kitchenOrder->items()->count() === 0) {
                     $kitchenOrder->delete();
                 }

--- a/app/Models/ThirdPartyOrder.php
+++ b/app/Models/ThirdPartyOrder.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Traits\HasUuid;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Services\KitchenService;
 
 class ThirdPartyOrder extends Model
 {
@@ -16,11 +17,13 @@ class ThirdPartyOrder extends Model
         'table_name',
         'total',
         'ordered_at',
+        'invoiced_at',
     ];
 
     protected $casts = [
         'total' => 'integer',
         'ordered_at' => 'datetime',
+        'invoiced_at' => 'datetime',
     ];
 
     protected static function booted()
@@ -69,6 +72,9 @@ class ThirdPartyOrder extends Model
     {
         $orderIds = static::where('table_id', $tableId)->pluck('id');
         ThirdPartyOrderItem::whereIn('third_party_order_id', $orderIds)->delete();
+        // Stamp before soft-deleting: a trashed row with invoiced_at set means
+        // "closed by an invoice", as opposed to the 4am cleanup.
+        static::where('table_id', $tableId)->update(['invoiced_at' => now()]);
         return static::where('table_id', $tableId)->delete();
     }
 
@@ -114,27 +120,21 @@ class ThirdPartyOrder extends Model
             $order = static::find($orderId);
             if (!$order) continue;
 
-            $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
-                ->where('orderable_id', $orderId)
-                ->first();
-
             if ($order->items()->count() === 0) {
-                // Whole order paid: drop the kitchen order if it was already
-                // handed out, otherwise let the kitchen finish it and mark it
-                // as invoiced so it disappears the moment they do.
-                if ($kitchenOrder) {
-                    if ($kitchenOrder->ready_at !== null) {
-                        $kitchenOrder->items()->delete();
-                        $kitchenOrder->delete();
-                    } elseif ($kitchenOrder->invoiced_at === null) {
-                        $kitchenOrder->update(['invoiced_at' => now()]);
-                    }
-                }
+                // Whole order paid: ready kitchen orders are removed, unfinished
+                // ones stay on the display flagged as invoiced.
+                KitchenService::clearForInvoice('third_party_order', [$orderId]);
+                $order->update(['invoiced_at' => now()]);
                 $order->delete();
                 $ordersDeleted++;
             } else {
-                // Order still has un-invoiced items — clean up the kitchen order
-                // only if it ran out of kitchen items
+                // Order still has un-invoiced items. Active kitchen orders keep
+                // all their items (step 2 only touched ready ones), so only a
+                // handed-out kitchen order can have run out of kitchen items.
+                $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
+                    ->where('orderable_id', $orderId)
+                    ->ready()
+                    ->first();
                 if ($kitchenOrder && $kitchenOrder->items()->count() === 0) {
                     $kitchenOrder->delete();
                 }

--- a/app/Models/ThirdPartyOrderItem.php
+++ b/app/Models/ThirdPartyOrderItem.php
@@ -21,12 +21,14 @@ class ThirdPartyOrderItem extends Model
         'sku',
         'print_station_id',
         'active',
+        'invoiced_at',
     ];
 
     protected $casts = [
         'qty' => 'decimal:2',
         'price' => 'integer',
         'active' => 'integer',
+        'invoiced_at' => 'datetime',
     ];
 
     public function order()

--- a/database/migrations/2026_07_28_100000_add_invoiced_at_to_kitchen_orders_table.php
+++ b/database/migrations/2026_07_28_100000_add_invoiced_at_to_kitchen_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('kitchen_orders', function (Blueprint $table) {
+            $table->timestamp('invoiced_at')->nullable()->after('ready_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('kitchen_orders', function (Blueprint $table) {
+            $table->dropColumn('invoiced_at');
+        });
+    }
+};

--- a/database/migrations/2026_08_23_100000_add_invoiced_at_to_third_party_orders_table.php
+++ b/database/migrations/2026_08_23_100000_add_invoiced_at_to_third_party_orders_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Stamped when an invoice closes the order (both the listastavki and the
+     * stoid paths). Lets the sync endpoint tell "closed by an invoice" apart
+     * from "soft-deleted by the 4am cleanup" when the external system resends
+     * an order id.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('third_party_orders', function (Blueprint $table) {
+            $table->timestamp('invoiced_at')->nullable()->after('ordered_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('third_party_orders', function (Blueprint $table) {
+            $table->dropColumn('invoiced_at');
+        });
+    }
+};

--- a/database/migrations/2026_08_23_120000_add_invoiced_at_to_third_party_order_items_table.php
+++ b/database/migrations/2026_08_23_120000_add_invoiced_at_to_third_party_order_items_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Stamped when a partial invoice (listastavki) pays the item. Lets a
+     * resend tell "soft-deleted because it was paid" (skip it) apart from
+     * "soft-deleted because a sync pruned it" (restore it when re-added).
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('third_party_order_items', function (Blueprint $table) {
+            $table->timestamp('invoiced_at')->nullable()->after('active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('third_party_order_items', function (Blueprint $table) {
+            $table->dropColumn('invoiced_at');
+        });
+    }
+};

--- a/resources/js/components/Kitchen/KitchenOrderCard.vue
+++ b/resources/js/components/Kitchen/KitchenOrderCard.vue
@@ -14,7 +14,15 @@
         class="absolute inset-0 bg-white/20"
         :style="{ width: fillWidth, transition: 'width 3s linear' }"
       ></div>
-      <span class="relative text-white font-bold text-lg">{{ order.table_name }}</span>
+      <div class="relative flex items-center gap-2">
+        <span class="text-white font-bold text-lg">{{ order.table_name }}</span>
+        <span
+          v-if="order.invoiced_at && mode === 'active'"
+          class="inline-flex items-center px-2 py-0.5 rounded bg-yellow-400 text-gray-900 text-xs font-bold tracking-wide"
+        >
+          PLAĆENO
+        </span>
+      </div>
       <span v-if="order.waiter_name" class="relative text-white font-normal text-lg">{{ order.waiter_name }}</span>
       <template v-if="mode === 'active'">
         <button

--- a/services/KitchenService.php
+++ b/services/KitchenService.php
@@ -13,6 +13,20 @@ use Illuminate\Support\Facades\Cache;
 class KitchenService
 {
     /**
+     * Request-scoped memo for inventory lookups. A batch payload repeats the
+     * same articles across tables; without this every kitchen item costs an
+     * unindexable inventory scan.
+     */
+    private static array $inventoryMatchCache = [];
+    private static array $inventoryCategoryCache = [];
+
+    public static function resetInventoryCache(): void
+    {
+        self::$inventoryMatchCache = [];
+        self::$inventoryCategoryCache = [];
+    }
+
+    /**
      * Format a table name with the appropriate prefix for kitchen display.
      *
      * @param string $tableName
@@ -86,24 +100,43 @@ class KitchenService
      */
     public static function matchInventory(?string $sku, ?string $name): ?int
     {
+        $cacheKey = ($sku ?? "\0") . '|' . ($name ?? "\0");
+        if (array_key_exists($cacheKey, self::$inventoryMatchCache)) {
+            return self::$inventoryMatchCache[$cacheKey];
+        }
+
+        $result = null;
+
         // First, try to match by SKU as integer comparison
         if ($sku !== null && $sku !== '') {
             $skuInt = (int) $sku;
             $inventory = Inventory::whereRaw('sku + 0 = ?', [$skuInt])->first();
             if ($inventory) {
-                return $inventory->id;
+                $result = $inventory->id;
             }
         }
 
         // Fallback: try to match by name (case-insensitive)
-        if ($name) {
+        if ($result === null && $name) {
             $inventory = Inventory::whereRaw('LOWER(name) = ?', [strtolower($name)])->first();
             if ($inventory) {
-                return $inventory->id;
+                $result = $inventory->id;
             }
         }
 
-        return null;
+        return self::$inventoryMatchCache[$cacheKey] = $result;
+    }
+
+    /**
+     * Memoized lookup of an inventory item's category.
+     */
+    private static function inventoryCategoryId(int $inventoryId): ?int
+    {
+        if (!array_key_exists($inventoryId, self::$inventoryCategoryCache)) {
+            self::$inventoryCategoryCache[$inventoryId] = Inventory::find($inventoryId)?->category_id;
+        }
+
+        return self::$inventoryCategoryCache[$inventoryId];
     }
 
     /**
@@ -144,9 +177,11 @@ class KitchenService
      * Process a POS order and create/update a kitchen order for kitchen items.
      *
      * @param Order $order
+     * @param bool $broadcast Set false when the caller batches several orders
+     *                        and fires a single broadcast at the end.
      * @return KitchenOrder|null
      */
-    public static function processOrder(Order $order): ?KitchenOrder
+    public static function processOrder(Order $order, bool $broadcast = true): ?KitchenOrder
     {
         $kitchenCategoryIds = self::getKitchenCategoryIds();
         $orderItems = $order->order ?? [];
@@ -201,10 +236,12 @@ class KitchenService
             $kitchenOrder->items()->create($item);
         }
 
-        try {
-            app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
-        } catch (\Exception $e) {
-            \Log::error($e->getMessage());
+        if ($broadcast) {
+            try {
+                app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
+            } catch (\Exception $e) {
+                \Log::error($e->getMessage());
+            }
         }
 
         return $kitchenOrder;
@@ -215,9 +252,12 @@ class KitchenService
      * Uses print_station_id == 2 to detect kitchen items.
      *
      * @param ThirdPartyOrder $order
+     * @param string|null $waiterName
+     * @param bool $broadcast Set false when the caller batches several orders
+     *                        and fires a single broadcast at the end.
      * @return KitchenOrder|null
      */
-    public static function processThirdPartyOrder(ThirdPartyOrder $order, ?string $waiterName = null): ?KitchenOrder
+    public static function processThirdPartyOrder(ThirdPartyOrder $order, ?string $waiterName = null, bool $broadcast = true): ?KitchenOrder
     {
         $order->load('items');
 
@@ -268,7 +308,7 @@ class KitchenService
             $incomingExternalIds[] = $item->external_item_id;
 
             $inventoryId = self::matchInventory($item->sku, $item->name);
-            $categoryId = $inventoryId ? Inventory::find($inventoryId)?->category_id : null;
+            $categoryId = $inventoryId ? self::inventoryCategoryId($inventoryId) : null;
 
             $kitchenOrder->items()->updateOrCreate(
                 ['external_item_id' => $item->external_item_id],
@@ -288,16 +328,20 @@ class KitchenService
             ->whereNotIn('external_item_id', $incomingExternalIds)
             ->delete();
 
-        // Only reset ready_at if new items were actually added
+        // Only reset ready_at if new items were actually added. New items also
+        // mean the order is no longer fully paid, so the invoiced flag must go
+        // too — otherwise the fresh food would vanish on the next "ready".
         $hasNewItems = !empty(array_diff($incomingExternalIds, $existingExternalIds));
-        if ($kitchenOrder->ready_at !== null && $hasNewItems) {
-            $kitchenOrder->update(['ready_at' => null]);
+        if ($hasNewItems && ($kitchenOrder->ready_at !== null || $kitchenOrder->invoiced_at !== null)) {
+            $kitchenOrder->update(['ready_at' => null, 'invoiced_at' => null]);
         }
 
-        try {
-            app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
-        } catch (\Exception $e) {
-            \Log::error($e->getMessage());
+        if ($broadcast) {
+            try {
+                app(Pusher::class)->trigger('broadcasting', 'kitchen-update', []);
+            } catch (\Exception $e) {
+                \Log::error($e->getMessage());
+            }
         }
 
         return $kitchenOrder;

--- a/services/KitchenService.php
+++ b/services/KitchenService.php
@@ -107,6 +107,40 @@ class KitchenService
     }
 
     /**
+     * Clear kitchen orders whose bill was just cashed out.
+     *
+     * Orders already handed out ("Izdate") are deleted. Orders the kitchen is
+     * still preparing stay on the display and are only stamped as invoiced —
+     * they disappear once the kitchen marks them ready.
+     *
+     * @param string $orderableType 'order' or 'third_party_order'
+     * @param array $orderableIds
+     * @return void
+     */
+    public static function clearForInvoice(string $orderableType, array $orderableIds): void
+    {
+        if (empty($orderableIds)) {
+            return;
+        }
+
+        $readyKitchenOrders = KitchenOrder::where('orderable_type', $orderableType)
+            ->whereIn('orderable_id', $orderableIds)
+            ->ready()
+            ->get();
+
+        foreach ($readyKitchenOrders as $readyKitchenOrder) {
+            $readyKitchenOrder->items()->delete();
+            $readyKitchenOrder->delete();
+        }
+
+        KitchenOrder::where('orderable_type', $orderableType)
+            ->whereIn('orderable_id', $orderableIds)
+            ->active()
+            ->whereNull('invoiced_at')
+            ->update(['invoiced_at' => now()]);
+    }
+
+    /**
      * Process a POS order and create/update a kitchen order for kitchen items.
      *
      * @param Order $order

--- a/services/KitchenService.php
+++ b/services/KitchenService.php
@@ -323,9 +323,18 @@ class KitchenService
             );
         }
 
-        // Remove items no longer present in the order
+        // Remove items no longer present in the order — but keep items whose
+        // bill was paid while the kitchen is still preparing them (their TPO
+        // item is soft-deleted with the invoiced stamp; the invoice path
+        // deliberately left them on the display for active kitchen orders).
+        $paidItemIds = $order->items()
+            ->onlyTrashed()
+            ->whereNotNull('invoiced_at')
+            ->pluck('external_item_id')
+            ->toArray();
+
         $kitchenOrder->items()
-            ->whereNotIn('external_item_id', $incomingExternalIds)
+            ->whereNotIn('external_item_id', array_merge($incomingExternalIds, $paidItemIds))
             ->delete();
 
         // Only reset ready_at if new items were actually added. New items also

--- a/tests/Feature/KitchenOrderTest.php
+++ b/tests/Feature/KitchenOrderTest.php
@@ -4,12 +4,14 @@ namespace Tests\Feature;
 
 use App\Models\Category;
 use App\Models\Inventory;
+use App\Models\Invoice;
 use App\Models\KitchenOrder;
 use App\Models\KitchenOrderItem;
 use App\Models\Order;
 use App\Models\Table;
 use App\Models\ThirdPartyOrder;
 use App\Models\ThirdPartyOrderItem;
+use App\Models\User;
 use App\Http\Middleware\VerifyExternalApiKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -55,6 +57,90 @@ class KitchenOrderTest extends TestCase
 
         $kitchenOrder->refresh();
         $this->assertNotNull($kitchenOrder->ready_at);
+    }
+
+    /**
+     * An order whose bill was already paid is removed when the kitchen marks it
+     * ready — it must never land in "Izdate", because nothing clears it there.
+     */
+    public function test_invoiced_kitchen_order_is_deleted_on_mark_ready()
+    {
+        $kitchenOrder = $this->createKitchenOrderWithItems(['invoiced_at' => now()]);
+
+        $response = $this->postJson("/api/kitchen/orders/{$kitchenOrder->id}/ready");
+
+        $response->assertStatus(200);
+        $response->assertJson(['deleted' => true]);
+
+        $this->assertEquals(0, KitchenOrder::count(), 'The paid order should be gone');
+        $this->assertEquals(0, KitchenOrderItem::count(), 'Its items should be gone too');
+
+        $index = $this->getJson('/api/kitchen/orders');
+        $this->assertEmpty($index->json('active'));
+        $this->assertEmpty($index->json('ready'), 'A paid order should never reach "Izdate"');
+    }
+
+    /**
+     * Cashing out a POS table keeps unfinished kitchen orders on the display
+     * (flagged as paid) and clears only the ones already handed out.
+     */
+    public function test_pos_invoice_keeps_active_kitchen_order_and_deletes_ready_one()
+    {
+        $waiter = User::create([
+            'name' => 'Miloš',
+            'username' => 'milos',
+            'password' => bcrypt('secret'),
+        ]);
+        $table = Table::create(['name' => '5', 'area' => 1, 'table_number' => 5]);
+
+        $stillCooking = Order::create(['table_id' => $table->id, 'total' => 500, 'order' => []]);
+        $alreadyServed = Order::create(['table_id' => $table->id, 'total' => 300, 'order' => []]);
+
+        $activeKitchenOrder = $this->createKitchenOrderWithItems([
+            'orderable_id' => $stillCooking->id,
+        ]);
+        $readyKitchenOrder = $this->createKitchenOrderWithItems([
+            'orderable_id' => $alreadyServed->id,
+            'ready_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/invoices', [
+            'user_id' => $waiter->id,
+            'table_id' => $table->id,
+            'total' => 800,
+            'status' => Invoice::STATUS_REFUNDED,
+            'order' => [['name' => 'Cevapi', 'qty' => 2, 'price' => 400]],
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertEquals(0, Order::count(), 'Both POS orders should be cashed out');
+
+        $this->assertNull(
+            KitchenOrder::find($readyKitchenOrder->id),
+            'The order already in "Izdate" should be deleted by the invoice'
+        );
+        $this->assertNotNull(
+            KitchenOrder::find($activeKitchenOrder->id),
+            'The order the kitchen is still preparing should stay on the display'
+        );
+        $this->assertNotNull(
+            $activeKitchenOrder->fresh()->invoiced_at,
+            'It should be flagged as invoiced so it disappears once marked ready'
+        );
+    }
+
+    /**
+     * The kitchen display exposes invoiced_at so a paid order can be marked.
+     */
+    public function test_invoiced_at_is_returned_in_index()
+    {
+        $this->createKitchenOrderWithItems(['invoiced_at' => now()]);
+
+        $response = $this->getJson('/api/kitchen/orders');
+
+        $response->assertStatus(200);
+        $this->assertNotNull($response->json('active.0.invoiced_at'));
     }
 
     /**

--- a/tests/Feature/KitchenOrderTest.php
+++ b/tests/Feature/KitchenOrderTest.php
@@ -131,6 +131,128 @@ class KitchenOrderTest extends TestCase
     }
 
     /**
+     * The same cash-out through the real path waiters use (a PAYED invoice,
+     * which also runs SalesService) keeps the unfinished kitchen order too.
+     */
+    public function test_paid_pos_invoice_runs_sales_and_keeps_active_kitchen_order()
+    {
+        $waiter = User::create([
+            'name' => 'Miloš',
+            'username' => 'milos2',
+            'password' => bcrypt('secret'),
+        ]);
+        $table = Table::create(['name' => '6', 'area' => 1, 'table_number' => 6]);
+
+        $stillCooking = Order::create(['table_id' => $table->id, 'total' => 500, 'order' => []]);
+        $alreadyServed = Order::create(['table_id' => $table->id, 'total' => 300, 'order' => []]);
+
+        $activeKitchenOrder = $this->createKitchenOrderWithItems([
+            'orderable_id' => $stillCooking->id,
+        ]);
+        $readyKitchenOrder = $this->createKitchenOrderWithItems([
+            'orderable_id' => $alreadyServed->id,
+            'ready_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/invoices', [
+            'user_id' => $waiter->id,
+            'table_id' => $table->id,
+            'total' => 800,
+            'status' => \App\Models\Invoice::STATUS_PAYED,
+            'order' => [[
+                'id' => 1,
+                'name' => 'Cevapi',
+                'qty' => 2,
+                'price' => 400,
+                'category_id' => 1,
+                'category_name' => 'Roštilj',
+                'table_id' => $table->id,
+                'sku' => '000055',
+            ]],
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertEquals(0, Order::count(), 'Both POS orders should be cashed out');
+        $this->assertEquals(
+            1,
+            \App\Models\Sales::count(),
+            'A PAYED invoice must record the sale'
+        );
+
+        $this->assertNull(
+            KitchenOrder::find($readyKitchenOrder->id),
+            'The order already in "Izdate" should be deleted by the invoice'
+        );
+        $activeKitchenOrder = $activeKitchenOrder->fresh();
+        $this->assertNotNull(
+            $activeKitchenOrder,
+            'The order the kitchen is still preparing should stay on the display'
+        );
+        $this->assertNotNull($activeKitchenOrder->invoiced_at);
+    }
+
+    /**
+     * New items arriving on a kitchen order already flagged as invoiced mean
+     * the order is no longer fully paid — the flag (and ready state) must be
+     * cleared so the fresh food does not vanish on the next "ready".
+     */
+    public function test_new_items_clear_invoiced_flag_on_kitchen_order()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 700001,
+            'table_id' => 7,
+            'table_name' => '7',
+            'total' => 300,
+        ]);
+        ThirdPartyOrderItem::create([
+            'third_party_order_id' => $order->id,
+            'external_item_id' => 71,
+            'name' => 'Cevapi',
+            'qty' => 1,
+            'price' => 300,
+            'unit' => 'kom',
+            'active' => 1,
+            'print_station_id' => 2,
+        ]);
+
+        $kitchenOrder = KitchenOrder::create([
+            'orderable_type' => 'third_party_order',
+            'orderable_id' => $order->id,
+            'table_name' => 'Sala 7',
+            'ready_at' => now(),
+            'invoiced_at' => now(),
+        ]);
+        KitchenOrderItem::create([
+            'kitchen_order_id' => $kitchenOrder->id,
+            'external_item_id' => 71,
+            'name' => 'Cevapi',
+            'qty' => 1,
+            'storno' => false,
+            'is_done' => false,
+        ]);
+
+        // A new (unpaid) item lands on the order
+        ThirdPartyOrderItem::create([
+            'third_party_order_id' => $order->id,
+            'external_item_id' => 72,
+            'name' => 'Pljeskavica',
+            'qty' => 1,
+            'price' => 350,
+            'unit' => 'kom',
+            'active' => 1,
+            'print_station_id' => 2,
+        ]);
+
+        \Services\KitchenService::processThirdPartyOrder($order->fresh());
+
+        $kitchenOrder = $kitchenOrder->fresh();
+        $this->assertNull($kitchenOrder->invoiced_at, 'New items mean the order is no longer fully paid');
+        $this->assertNull($kitchenOrder->ready_at, 'New items put the order back into "Aktivne"');
+        $this->assertEquals(2, $kitchenOrder->items()->count());
+    }
+
+    /**
      * The kitchen display exposes invoiced_at so a paid order can be marked.
      */
     public function test_invoiced_at_is_returned_in_index()
@@ -339,7 +461,8 @@ class KitchenOrderTest extends TestCase
     }
 
     /**
-     * Test invoiced orders are not re-added to kitchen display.
+     * An order already closed by an invoice this working day is skipped when
+     * the external system resends it — no ghost table, no kitchen dispatch.
      */
     public function test_invoiced_orders_not_re_added_to_kitchen()
     {
@@ -371,29 +494,33 @@ class KitchenOrderTest extends TestCase
             ->first();
         $this->assertNotNull($kitchenOrder, 'Kitchen order should exist after initial import');
 
-        // 2. Simulate invoice: soft-delete the order + hard-delete kitchen order
-        $order->delete(); // soft delete
-        $kitchenOrder->items()->delete();
-        $kitchenOrder->delete();
+        // 2. Close the order through the real invoice path (stamps invoiced_at)
+        ThirdPartyOrder::deleteByExternalItemIds([9001]);
 
         $this->assertNull(ThirdPartyOrder::find($order->id), 'Order should be soft-deleted');
-        $this->assertTrue(ThirdPartyOrder::onlyTrashed()->where('external_order_id', 999001)->exists());
-        $this->assertEquals(0, KitchenOrder::where('orderable_type', 'third_party_order')
-            ->where('orderable_id', $order->id)->count());
+        $trashed = ThirdPartyOrder::onlyTrashed()->where('external_order_id', 999001)->first();
+        $this->assertNotNull($trashed);
+        $this->assertNotNull($trashed->invoiced_at, 'Invoice path should stamp invoiced_at');
 
         // 3. Re-send the same order (ebar sends all orders for the table)
         $response = $this->postJson('/api/third-party-order', $payload);
         $response->assertStatus(201);
+        $response->assertJsonPath('summary.skipped_invoiced', [999001]);
 
-        // A new ThirdPartyOrder row is created (updateOrCreate doesn't find soft-deleted)
-        $newOrder = ThirdPartyOrder::where('external_order_id', 999001)->first();
-        $this->assertNotNull($newOrder);
+        // 4. The paid order does not come back at all — no ghost table row...
+        $this->assertNull(
+            ThirdPartyOrder::where('external_order_id', 999001)->first(),
+            'A resent paid order must not reappear as a live order'
+        );
 
-        // 4. Verify NO kitchen order was created for the re-sent invoiced order
-        $kitchenOrders = KitchenOrder::where('orderable_type', 'third_party_order')
-            ->where('orderable_id', $newOrder->id)
-            ->get();
-        $this->assertCount(0, $kitchenOrders, 'Invoiced order should NOT be re-added to kitchen');
+        // ...and no new kitchen dispatch: only the original (still unfinished,
+        // now flagged as invoiced) kitchen order remains on the display.
+        $this->assertEquals(
+            1,
+            KitchenOrder::where('orderable_type', 'third_party_order')->count(),
+            'Invoiced order should NOT be re-added to kitchen'
+        );
+        $this->assertNotNull($kitchenOrder->fresh()->invoiced_at);
     }
 
     /**

--- a/tests/Feature/ThirdPartyInvoiceOrderClearingTest.php
+++ b/tests/Feature/ThirdPartyInvoiceOrderClearingTest.php
@@ -204,9 +204,10 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
     }
 
     /**
-     * Test that deleteByExternalItemIds also deletes matching KitchenOrderItems.
+     * An active (not yet handed out) kitchen order keeps all of its items when
+     * the bill is paid — the kitchen still has to prepare that food.
      */
-    public function test_deleteByExternalItemIds_deletes_kitchen_order_items()
+    public function test_deleteByExternalItemIds_keeps_kitchen_items_of_active_orders()
     {
         $order = ThirdPartyOrder::create([
             'external_order_id' => 104130,
@@ -284,6 +285,61 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
         ThirdPartyOrder::deleteByExternalItemIds([326984, 326998]);
 
         $this->assertEquals(
+            3,
+            KitchenOrderItem::count(),
+            'All kitchen items stay on the display — the kitchen has not handed this order out yet'
+        );
+        $this->assertNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'Order 327010 is still un-invoiced, so the kitchen order is not flagged as paid yet'
+        );
+    }
+
+    /**
+     * A kitchen order already handed out ("Izdate") is cleaned up as before.
+     */
+    public function test_deleteByExternalItemIds_deletes_kitchen_order_items_when_ready()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 104130,
+            'table_id' => 2,
+            'table_name' => '2',
+            'total' => 630,
+        ]);
+
+        foreach ([326984, 326998, 327010] as $externalItemId) {
+            ThirdPartyOrderItem::create([
+                'third_party_order_id' => $order->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'price' => 210,
+                'unit' => 'kom',
+                'active' => 1,
+            ]);
+        }
+
+        $kitchenOrder = KitchenOrder::create([
+            'orderable_type' => 'third_party_order',
+            'orderable_id' => $order->id,
+            'table_name' => 'Sala 2',
+            'ready_at' => now(),
+        ]);
+
+        foreach ([326984, 326998, 327010] as $externalItemId) {
+            KitchenOrderItem::create([
+                'kitchen_order_id' => $kitchenOrder->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'storno' => false,
+                'is_done' => false,
+            ]);
+        }
+
+        ThirdPartyOrder::deleteByExternalItemIds([326984, 326998]);
+
+        $this->assertEquals(
             1,
             KitchenOrderItem::count(),
             'Only the kitchen item for 327010 should remain after deleting items 326984 and 326998'
@@ -295,9 +351,10 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
     }
 
     /**
-     * Test full cascade: items deleted -> order empty -> kitchen order also deleted.
+     * Whole order paid while the kitchen is still preparing it: the kitchen
+     * order survives, flagged as invoiced, so the food still gets made.
      */
-    public function test_deleteByExternalItemIds_deletes_kitchen_order_when_order_empty()
+    public function test_deleteByExternalItemIds_flags_active_kitchen_order_when_order_empty()
     {
         $order = ThirdPartyOrder::create([
             'external_order_id' => 104130,
@@ -361,14 +418,76 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
             'ThirdPartyOrder should be soft-deleted when all items are removed'
         );
         $this->assertEquals(
+            1,
+            KitchenOrder::count(),
+            'KitchenOrder should stay on the display — the kitchen has not handed it out yet'
+        );
+        $this->assertEquals(
+            2,
+            KitchenOrderItem::count(),
+            'Kitchen items stay so the kitchen still knows what to prepare'
+        );
+        $this->assertNotNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'KitchenOrder should be flagged as invoiced so it disappears once marked ready'
+        );
+    }
+
+    /**
+     * Same scenario, but the kitchen already handed the order out: it is
+     * deleted at invoice time, as before.
+     */
+    public function test_deleteByExternalItemIds_deletes_ready_kitchen_order_when_order_empty()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 104130,
+            'table_id' => 2,
+            'table_name' => '2',
+            'total' => 420,
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            ThirdPartyOrderItem::create([
+                'third_party_order_id' => $order->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'price' => 210,
+                'unit' => 'kom',
+                'active' => 1,
+            ]);
+        }
+
+        $kitchenOrder = KitchenOrder::create([
+            'orderable_type' => 'third_party_order',
+            'orderable_id' => $order->id,
+            'table_name' => 'Sala 2',
+            'ready_at' => now(),
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            KitchenOrderItem::create([
+                'kitchen_order_id' => $kitchenOrder->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'storno' => false,
+                'is_done' => false,
+            ]);
+        }
+
+        $deleted = ThirdPartyOrder::deleteByExternalItemIds([326984, 326998]);
+
+        $this->assertEquals(1, $deleted, 'Should delete 1 order');
+        $this->assertEquals(
             0,
             KitchenOrder::count(),
-            'KitchenOrder should be deleted when its parent order has no items left'
+            'A kitchen order already in "Izdate" should be deleted when its parent order is paid'
         );
         $this->assertEquals(
             0,
             KitchenOrderItem::count(),
-            'KitchenOrderItems should be deleted along with their kitchen order items'
+            'Its items should go with it'
         );
     }
 
@@ -460,9 +579,13 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
             'Kitchen order should persist because the parent order still has items'
         );
         $this->assertEquals(
-            1,
+            3,
             KitchenOrderItem::count(),
-            'Only kitchen item 327010 should remain'
+            'Kitchen items are untouched while the order is still being prepared'
+        );
+        $this->assertNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'A partially invoiced order is not flagged as paid'
         );
     }
 
@@ -1414,9 +1537,10 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
     // =========================================================================
 
     /**
-     * Test that kitchen orders are cleared when an invoice clears all items.
+     * An invoice clearing all items keeps an unfinished kitchen order on the
+     * display and flags it as paid.
      */
-    public function test_kitchen_orders_cleared_when_invoice_clears_all_items()
+    public function test_active_kitchen_order_survives_invoice_and_is_flagged()
     {
         $order = ThirdPartyOrder::create([
             'external_order_id' => 104130,
@@ -1495,21 +1619,107 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
         $response->assertStatus(201);
 
         $this->assertEquals(
+            1,
+            KitchenOrder::count(),
+            'Kitchen order should stay on the display so the kitchen can finish it'
+        );
+        $this->assertEquals(
+            2,
+            KitchenOrderItem::count(),
+            'Kitchen order items should stay with it'
+        );
+        $this->assertNotNull(
+            $kitchenOrder->fresh()->invoiced_at,
+            'Kitchen order should be flagged as invoiced'
+        );
+
+        // Marking it ready now removes it instead of moving it to "Izdate"
+        $this->postJson("/api/kitchen/orders/{$kitchenOrder->id}/ready")->assertStatus(200);
+
+        $this->assertEquals(0, KitchenOrder::count(), 'Paid order should disappear when marked ready');
+        $this->assertEquals(0, KitchenOrderItem::count(), 'Its items should go with it');
+    }
+
+    /**
+     * A kitchen order already handed out is deleted by the invoice, as before.
+     */
+    public function test_ready_kitchen_order_is_deleted_by_invoice()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 104130,
+            'table_id' => 2,
+            'table_name' => '2',
+            'total' => 420,
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            ThirdPartyOrderItem::create([
+                'third_party_order_id' => $order->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'price' => 210,
+                'unit' => 'kom',
+                'active' => 1,
+            ]);
+        }
+
+        $kitchenOrder = KitchenOrder::create([
+            'orderable_type' => 'third_party_order',
+            'orderable_id' => $order->id,
+            'table_name' => 'Sala 2',
+            'ready_at' => now(),
+        ]);
+
+        foreach ([326984, 326998] as $externalItemId) {
+            KitchenOrderItem::create([
+                'kitchen_order_id' => $kitchenOrder->id,
+                'external_item_id' => $externalItemId,
+                'name' => 'Item ' . $externalItemId,
+                'qty' => 1,
+                'storno' => false,
+                'is_done' => false,
+            ]);
+        }
+
+        $response = $this->postJson('/api/third-party-invoice', [
+            [
+                'kolicina' => 2,
+                'cena' => 210,
+                'naziv' => 'Drinks',
+                'jm' => 'kom',
+                'gotovina' => 420,
+                'kartica' => 0,
+                'prenosnaracun' => 0,
+                'datum' => '2026-02-23 22:01:10',
+                'brojracuna' => 29926,
+                'sto' => '2',
+                'stoid' => 2,
+                'racunid' => 42949,
+                'stornirano' => 0,
+                'listastavki' => '326984, 326998',
+            ],
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertEquals(
             0,
             KitchenOrder::count(),
-            'Kitchen order should be deleted when all its items are cleared via invoice'
+            'Kitchen order already in "Izdate" should be deleted when the bill is paid'
         );
         $this->assertEquals(
             0,
             KitchenOrderItem::count(),
-            'Kitchen order items should be deleted when cleared via invoice listastavki'
+            'Kitchen order items should be deleted with it'
         );
     }
 
     /**
-     * Test that the kitchen display API excludes cleared orders after invoice processing.
+     * The kitchen display keeps listing an unfinished order after its bill is
+     * paid, and drops it the moment the kitchen marks it ready.
      */
-    public function test_kitchen_display_api_excludes_cleared_orders()
+    public function test_kitchen_display_api_keeps_active_order_after_invoice()
     {
         // Create order and kitchen order
         $order = ThirdPartyOrder::create([
@@ -1572,14 +1782,27 @@ class ThirdPartyInvoiceOrderClearingTest extends TestCase
 
         $response->assertStatus(201);
 
-        // Verify kitchen order is gone from the API
+        // The order is still being prepared, so it stays in the active list
         $kitchenResponse = $this->getJson('/api/kitchen/orders');
         $kitchenResponse->assertStatus(200);
         $activeOrders = $kitchenResponse->json('active');
-        $this->assertEmpty(
+        $this->assertCount(
+            1,
             $activeOrders,
-            'Kitchen order should NOT appear in active list after invoice cleared its items'
+            'Kitchen order should still appear in the active list after its bill was paid'
         );
+        $this->assertNotNull(
+            $activeOrders[0]['invoiced_at'],
+            'The API should expose invoiced_at so the display can mark it as paid'
+        );
+
+        // Once the kitchen marks it ready it disappears instead of moving to "Izdate"
+        $this->postJson("/api/kitchen/orders/{$kitchenOrder->id}/ready")->assertStatus(200);
+
+        $kitchenResponse = $this->getJson('/api/kitchen/orders');
+        $kitchenResponse->assertStatus(200);
+        $this->assertEmpty($kitchenResponse->json('active'), 'Should be gone from active');
+        $this->assertEmpty($kitchenResponse->json('ready'), 'Should never reach "Izdate"');
     }
 
     // =========================================================================

--- a/tests/Feature/ThirdPartyOrderBatchTest.php
+++ b/tests/Feature/ThirdPartyOrderBatchTest.php
@@ -182,7 +182,10 @@ class ThirdPartyOrderBatchTest extends TestCase
 
         $response = $this->postJson('/api/third-party-order', $payload);
 
-        $response->assertStatus(201);
+        // Non-2xx (the pre-batch contract) so a retrying client resends; the
+        // good groups below stay committed and a resend is idempotent.
+        $response->assertStatus(500);
+        $response->assertJsonPath('success', false);
         $response->assertJsonPath('summary.processed', 2);
         $response->assertJsonPath('summary.failed.0.external_order_id', 230002);
 
@@ -420,5 +423,135 @@ class ThirdPartyOrderBatchTest extends TestCase
             'No duplicate row for the paid item'
         );
         $this->assertEquals(500, $order->total, 'The paid item stays out of the total');
+    }
+
+    public function test_resend_keeps_paid_but_unprepared_dish_on_the_kitchen_display()
+    {
+        // Two kitchen dishes on one order, kitchen still preparing both
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(610001, 6101, ['cena' => 100]),
+            $this->orderRow(610001, 6102, ['cena' => 200]),
+        ])->assertStatus(201);
+
+        $order = ThirdPartyOrder::where('external_order_id', 610001)->first();
+        $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
+            ->where('orderable_id', $order->id)
+            ->first();
+        $this->assertEquals(2, $kitchenOrder->items()->count());
+
+        // A partial invoice pays dish 6101; the active kitchen order keeps it
+        // (the kitchen still has to cook it)
+        $this->closeByInvoice([6101]);
+        $this->assertEquals(2, $kitchenOrder->items()->count());
+
+        // Any table change makes ebar resend the whole order
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(610001, 6101, ['cena' => 100]),
+            $this->orderRow(610001, 6102, ['cena' => 200]),
+        ])->assertStatus(201);
+
+        $this->assertEquals(
+            2,
+            $kitchenOrder->fresh()->items()->count(),
+            'The paid-but-unprepared dish must survive a routine resend'
+        );
+        $order = $order->fresh();
+        $this->assertEquals(1, $order->items()->count(), 'Paid item stays off the order');
+        $this->assertEquals(200, $order->total, 'Paid item stays out of the total');
+    }
+
+    public function test_item_removed_then_readded_with_same_id_is_restored()
+    {
+        // Order with dishes A + B
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(620001, 6201, ['cena' => 100]),
+            $this->orderRow(620001, 6202, ['cena' => 200]),
+        ])->assertStatus(201);
+
+        // Waiter removes B: the next sync omits it, so it gets pruned
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(620001, 6201, ['cena' => 100]),
+        ])->assertStatus(201);
+
+        $order = ThirdPartyOrder::where('external_order_id', 620001)->first();
+        $this->assertEquals(1, $order->items()->count());
+
+        // Waiter re-adds it and ebar resends both rows
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(620001, 6201, ['cena' => 100]),
+            $this->orderRow(620001, 6202, ['cena' => 200]),
+        ])->assertStatus(201);
+
+        $order = $order->fresh();
+        $this->assertEquals(2, $order->items()->count(), 'The re-added item must come back');
+        $this->assertEquals(
+            1,
+            ThirdPartyOrderItem::withTrashed()->where('external_item_id', 6202)->count(),
+            'Restored, not duplicated'
+        );
+        $this->assertEquals(300, $order->total);
+
+        $kitchenOrder = KitchenOrder::where('orderable_type', 'third_party_order')
+            ->where('orderable_id', $order->id)
+            ->first();
+        $this->assertEquals(2, $kitchenOrder->items()->count(), 'Back on the kitchen display too');
+    }
+
+    public function test_stornoed_bill_reopens_the_table_the_same_working_day()
+    {
+        // 1. Table synced, then cashed out through the real invoice endpoint
+        //    (stoid path: stamps invoiced_at and soft-deletes the order)
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(630001, 6301, ['stoid' => 12, 'sto' => '12']),
+        ])->assertStatus(201);
+
+        $this->postJson('/api/third-party-invoice', [[
+            'kolicina' => 1,
+            'cena' => 100,
+            'naziv' => 'Item 6301',
+            'jm' => 'kom',
+            'gotovina' => 100,
+            'kartica' => 0,
+            'prenosnaracun' => 0,
+            'datum' => now()->toDateTimeString(),
+            'brojracuna' => 88001,
+            'racunid' => 88001,
+            'sto' => '12',
+            'stoid' => 12,
+            'porudzbinaid' => 630001,
+            'stornirano' => 0,
+        ]])->assertStatus(201);
+
+        $trashed = ThirdPartyOrder::onlyTrashed()->where('external_order_id', 630001)->first();
+        $this->assertNotNull($trashed);
+        $this->assertNotNull($trashed->invoiced_at, 'Invoice close stamps the order');
+
+        // Sanity: while the bill stands, a resend is skipped
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(630001, 6301, ['stoid' => 12, 'sto' => '12']),
+        ])->assertJsonPath('summary.skipped_invoiced', [630001]);
+
+        // 2. The bill is stornoed — the table is open again
+        $this->postJson('/api/third-party-invoice', [[
+            'stornoreferenceid' => 88001,
+            'datum' => now()->toDateTimeString(),
+        ]])->assertStatus(200);
+
+        // 3. ebar resends the order: it must come back and reach the kitchen
+        $response = $this->postJson('/api/third-party-order', [
+            $this->orderRow(630001, 6301, ['stoid' => 12, 'sto' => '12']),
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.skipped_invoiced', []);
+
+        $reopened = ThirdPartyOrder::where('external_order_id', 630001)->first();
+        $this->assertNotNull($reopened, 'Storno must reopen the table for resends');
+        $this->assertNotNull(
+            KitchenOrder::where('orderable_type', 'third_party_order')
+                ->where('orderable_id', $reopened->id)
+                ->first(),
+            'The reopened order reaches the kitchen display'
+        );
     }
 }

--- a/tests/Feature/ThirdPartyOrderBatchTest.php
+++ b/tests/Feature/ThirdPartyOrderBatchTest.php
@@ -1,0 +1,424 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\ThirdPartyOrderController;
+use App\Http\Middleware\VerifyExternalApiKey;
+use App\Models\KitchenOrder;
+use App\Models\ThirdPartyInvoice;
+use App\Models\ThirdPartyOrder;
+use App\Models\ThirdPartyOrderItem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Services\Pusher;
+use Tests\TestCase;
+
+/**
+ * The external system (ebar) posts every active table in one request on
+ * startup, instead of one table at a time. These tests cover that batch
+ * behaviour: per-order isolation, resends of paid orders, id reuse across
+ * working days, and the single-broadcast guarantee.
+ */
+class ThirdPartyOrderBatchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private array $broadcastEvents = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(VerifyExternalApiKey::class);
+    }
+
+    /**
+     * Swap in a Pusher mock that records every triggered event name, so tests
+     * can count broadcasts (a batch must not fan out one call per order).
+     */
+    private function captureBroadcasts(): void
+    {
+        $this->broadcastEvents = [];
+        $mock = $this->createMock(Pusher::class);
+        $mock->method('trigger')
+            ->willReturnCallback(function ($channel, $event, $data) {
+                $this->broadcastEvents[] = $event;
+            });
+        $this->app->instance(Pusher::class, $mock);
+    }
+
+    private function broadcastCount(string $event): int
+    {
+        return collect($this->broadcastEvents)->filter(fn ($e) => $e === $event)->count();
+    }
+
+    /**
+     * A realistic ebar row. stampanjenalogaid = 2 marks a kitchen item.
+     */
+    private function orderRow(int $orderId, int $itemId, array $overrides = []): array
+    {
+        return array_merge([
+            'porudzbinaid' => $orderId,
+            'stavkaid' => $itemId,
+            'naziv' => 'Item ' . $itemId,
+            'kolicina' => 1,
+            'cena' => 100,
+            'jm' => 'kom',
+            'sto' => (string) (($orderId % 90) + 1),
+            'stoid' => ($orderId % 90) + 1,
+            'datum' => now()->toDateTimeString(),
+            'konobar' => 'Pera',
+            'stampanjenalogaid' => 2,
+        ], $overrides);
+    }
+
+    /**
+     * Close an order the way a real invoice does (listastavki path), which
+     * stamps invoiced_at before soft-deleting.
+     */
+    private function closeByInvoice(array $externalItemIds): void
+    {
+        ThirdPartyOrder::deleteByExternalItemIds($externalItemIds);
+    }
+
+    // =========================================================================
+    // Full snapshot
+    // =========================================================================
+
+    public function test_full_snapshot_of_thirty_tables_is_processed_with_one_broadcast()
+    {
+        $payload = [];
+        for ($i = 1; $i <= 30; $i++) {
+            $orderId = 200000 + $i;
+            // one kitchen item + one bar item per table
+            $payload[] = $this->orderRow($orderId, $orderId * 10 + 1, ['cena' => 100]);
+            $payload[] = $this->orderRow($orderId, $orderId * 10 + 2, [
+                'cena' => 150,
+                'stampanjenalogaid' => 1,
+            ]);
+        }
+
+        $this->captureBroadcasts();
+        $response = $this->postJson('/api/third-party-order', $payload);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.processed', 30);
+        $response->assertJsonPath('summary.created', 30);
+        $response->assertJsonPath('summary.failed', []);
+
+        $this->assertEquals(30, ThirdPartyOrder::count());
+        $this->assertEquals(60, ThirdPartyOrderItem::count());
+        $this->assertEquals(
+            30,
+            KitchenOrder::where('orderable_type', 'third_party_order')->count(),
+            'Every table with a kitchen item reaches the display'
+        );
+
+        $order = ThirdPartyOrder::where('external_order_id', 200001)->first();
+        $this->assertEquals(250, $order->total);
+        $this->assertEquals((200001 % 90) + 1, $order->table_id);
+
+        $this->assertEquals(1, $this->broadcastCount('tables-update'), 'One tables-update per request, not per order');
+        $this->assertEquals(1, $this->broadcastCount('kitchen-update'), 'One kitchen-update per request, not per order');
+    }
+
+    public function test_same_batch_posted_twice_is_idempotent()
+    {
+        $payload = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $orderId = 210000 + $i;
+            $payload[] = $this->orderRow($orderId, $orderId * 10 + 1);
+            $payload[] = $this->orderRow($orderId, $orderId * 10 + 2, ['cena' => 200]);
+        }
+
+        $this->postJson('/api/third-party-order', $payload)->assertStatus(201);
+        $totalsAfterFirst = ThirdPartyOrder::pluck('total', 'external_order_id')->toArray();
+
+        $response = $this->postJson('/api/third-party-order', $payload);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.created', 0);
+        $response->assertJsonPath('summary.updated', 5);
+
+        $this->assertEquals(5, ThirdPartyOrder::count(), 'No duplicate orders');
+        $this->assertEquals(10, ThirdPartyOrderItem::count(), 'No duplicate items');
+        $this->assertEquals(5, KitchenOrder::count(), 'No duplicate kitchen orders');
+        $this->assertEquals(
+            $totalsAfterFirst,
+            ThirdPartyOrder::pluck('total', 'external_order_id')->toArray(),
+            'Totals stay stable across resends'
+        );
+    }
+
+    public function test_modifier_rows_merge_per_order_across_a_batch()
+    {
+        $payload = [
+            $this->orderRow(220001, 100),
+            $this->orderRow(220001, 101, ['modifikatorslobodan' => 'bez luka', 'cena' => 0]),
+            $this->orderRow(220002, 200),
+            $this->orderRow(220002, 201, ['modifikatorslobodan' => 'ljuto', 'cena' => 0]),
+        ];
+
+        $this->postJson('/api/third-party-order', $payload)->assertStatus(201);
+
+        $this->assertEquals(2, ThirdPartyOrderItem::count(), 'Modifier rows are merged, not stored as items');
+
+        $first = ThirdPartyOrder::where('external_order_id', 220001)->first();
+        $this->assertEquals('bez luka', $first->items->first()->modifier);
+
+        $second = ThirdPartyOrder::where('external_order_id', 220002)->first();
+        $this->assertEquals('ljuto', $second->items->first()->modifier);
+    }
+
+    // =========================================================================
+    // Isolation and row hygiene
+    // =========================================================================
+
+    public function test_one_bad_order_does_not_break_the_rest_of_the_batch()
+    {
+        $payload = [
+            $this->orderRow(230001, 2301),
+            $this->orderRow(230002, 2302, ['datum' => 'not-a-date']),
+            $this->orderRow(230003, 2303),
+        ];
+
+        $response = $this->postJson('/api/third-party-order', $payload);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.processed', 2);
+        $response->assertJsonPath('summary.failed.0.external_order_id', 230002);
+
+        $this->assertNotNull(ThirdPartyOrder::where('external_order_id', 230001)->first());
+        $this->assertNull(ThirdPartyOrder::where('external_order_id', 230002)->first());
+        $this->assertNotNull(ThirdPartyOrder::where('external_order_id', 230003)->first());
+    }
+
+    public function test_rows_with_missing_or_invalid_porudzbinaid_are_skipped()
+    {
+        $validRow = $this->orderRow(240001, 2401);
+        $missing = $this->orderRow(240001, 2402);
+        unset($missing['porudzbinaid']);
+
+        $payload = [
+            $validRow,
+            $missing,
+            $this->orderRow(240001, 2403, ['porudzbinaid' => 'abc']),
+            $this->orderRow(240001, 2404, ['porudzbinaid' => 0]),
+        ];
+
+        $response = $this->postJson('/api/third-party-order', $payload);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.invalid_rows', 3);
+
+        $this->assertFalse(
+            ThirdPartyOrder::withTrashed()->where('external_order_id', 0)->exists(),
+            'Invalid rows must not collapse into a bogus order 0'
+        );
+        $this->assertEquals(1, ThirdPartyOrder::count());
+        $this->assertEquals(1, ThirdPartyOrderItem::count(), 'Only the valid row becomes an item');
+    }
+
+    public function test_payload_with_only_invalid_rows_is_rejected()
+    {
+        $row = $this->orderRow(250001, 2501);
+        unset($row['porudzbinaid']);
+
+        $response = $this->postJson('/api/third-party-order', [$row]);
+
+        $response->assertStatus(422);
+        $this->assertEquals(0, ThirdPartyOrder::count());
+    }
+
+    public function test_oversized_payload_is_rejected()
+    {
+        $payload = array_fill(0, ThirdPartyOrderController::MAX_ROWS + 1, ['porudzbinaid' => 1]);
+
+        $response = $this->postJson('/api/third-party-order', $payload);
+
+        $response->assertStatus(422);
+        $this->assertEquals(0, ThirdPartyOrder::count());
+    }
+
+    // =========================================================================
+    // Resends of orders an invoice already settled
+    // =========================================================================
+
+    public function test_resent_paid_order_is_skipped_not_resurrected()
+    {
+        // Table paid earlier this working day
+        $this->postJson('/api/third-party-order', [$this->orderRow(260001, 2601)])
+            ->assertStatus(201);
+        $this->closeByInvoice([2601]);
+
+        $this->assertEquals(0, ThirdPartyOrder::count());
+
+        // Startup sync resends it alongside a genuinely open table
+        $response = $this->postJson('/api/third-party-order', [
+            $this->orderRow(260001, 2601),
+            $this->orderRow(260002, 2602),
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.skipped_invoiced', [260001]);
+        $response->assertJsonPath('summary.created', 1);
+
+        $this->assertNull(
+            ThirdPartyOrder::where('external_order_id', 260001)->first(),
+            'The paid order must not come back as a ghost table'
+        );
+        $this->assertNotNull(ThirdPartyOrder::where('external_order_id', 260002)->first());
+    }
+
+    public function test_order_settled_by_a_paid_invoice_without_stamp_is_still_skipped()
+    {
+        // A row trashed before invoiced_at existed: bare soft delete, no stamp,
+        // but a paid invoice from this working day references the order id.
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 270001,
+            'table_id' => 3,
+            'table_name' => '3',
+            'total' => 100,
+        ]);
+        $order->delete();
+
+        ThirdPartyInvoice::create([
+            'invoice_number' => 'TP-270001',
+            'external_order_id' => 270001,
+            'status' => ThirdPartyInvoice::STATUS_PAYED,
+            'order' => [],
+            'total' => 100,
+            'payment_type' => ThirdPartyInvoice::PAYMENT_CASH,
+        ]);
+
+        $response = $this->postJson('/api/third-party-order', [$this->orderRow(270001, 2701)]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.skipped_invoiced', [270001]);
+        $this->assertNull(ThirdPartyOrder::where('external_order_id', 270001)->first());
+    }
+
+    public function test_stornoed_invoice_does_not_suppress_a_resend()
+    {
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 280001,
+            'table_id' => 4,
+            'table_name' => '4',
+            'total' => 100,
+        ]);
+        $order->delete();
+
+        ThirdPartyInvoice::create([
+            'invoice_number' => 'TP-280001',
+            'external_order_id' => 280001,
+            'status' => ThirdPartyInvoice::STATUS_STORNO,
+            'order' => [],
+            'total' => 100,
+            'payment_type' => ThirdPartyInvoice::PAYMENT_CASH,
+        ]);
+
+        $response = $this->postJson('/api/third-party-order', [$this->orderRow(280001, 2801)]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.skipped_invoiced', []);
+        $this->assertNotNull(
+            ThirdPartyOrder::where('external_order_id', 280001)->first(),
+            'A stornoed payment means the order is open again'
+        );
+    }
+
+    public function test_order_id_reused_after_a_previous_working_day_is_created()
+    {
+        // Settled YESTERDAY (previous working day) — ebar reuses porudzbinaid
+        // across days, so today's order with the same id is a new order.
+        $order = ThirdPartyOrder::create([
+            'external_order_id' => 290001,
+            'table_id' => 5,
+            'table_name' => '5',
+            'total' => 100,
+            'invoiced_at' => now()->subDay(),
+        ]);
+        $order->delete();
+
+        $invoice = ThirdPartyInvoice::create([
+            'invoice_number' => 'TP-290001',
+            'external_order_id' => 290001,
+            'status' => ThirdPartyInvoice::STATUS_PAYED,
+            'order' => [],
+            'total' => 100,
+            'payment_type' => ThirdPartyInvoice::PAYMENT_CASH,
+        ]);
+        $invoice->created_at = now()->subDay();
+        $invoice->save();
+
+        $response = $this->postJson('/api/third-party-order', [$this->orderRow(290001, 2901)]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.skipped_invoiced', []);
+        $this->assertNotNull(
+            ThirdPartyOrder::where('external_order_id', 290001)->first(),
+            'Yesterday\'s invoice must not blacklist a reused order id'
+        );
+    }
+
+    public function test_order_trashed_by_the_4am_cleanup_reaches_the_kitchen_when_resent()
+    {
+        // Regression: the old unbounded onlyTrashed() check meant any order id
+        // seen before the 4am cleanup never reached the kitchen again.
+        $this->postJson('/api/third-party-order', [$this->orderRow(300001, 3001)])
+            ->assertStatus(201);
+
+        $this->artisan('third-party-orders:cleanup');
+        $this->assertEquals(0, ThirdPartyOrder::count());
+
+        $response = $this->postJson('/api/third-party-order', [$this->orderRow(300001, 3001)]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('summary.created', 1);
+
+        $newOrder = ThirdPartyOrder::where('external_order_id', 300001)->first();
+        $this->assertNotNull($newOrder, 'A cleanup-trashed order is recreated on resend');
+        $this->assertNotNull(
+            KitchenOrder::where('orderable_type', 'third_party_order')
+                ->where('orderable_id', $newOrder->id)
+                ->first(),
+            'The resent order must reach the kitchen display'
+        );
+    }
+
+    // =========================================================================
+    // Partially paid orders
+    // =========================================================================
+
+    public function test_item_cleared_by_a_partial_invoice_is_not_resurrected_on_resend()
+    {
+        $this->postJson('/api/third-party-order', [
+            $this->orderRow(310001, 3101, ['cena' => 100]),
+            $this->orderRow(310001, 3102, ['cena' => 200]),
+            $this->orderRow(310001, 3103, ['cena' => 300]),
+        ])->assertStatus(201);
+
+        // Invoice pays item 3101 only (listastavki)
+        $this->closeByInvoice([3101]);
+
+        $order = ThirdPartyOrder::where('external_order_id', 310001)->first();
+        $this->assertNotNull($order, 'Order with remaining items stays open');
+        $this->assertEquals(2, $order->items()->count());
+
+        // ebar resends the whole order, paid item included
+        $response = $this->postJson('/api/third-party-order', [
+            $this->orderRow(310001, 3101, ['cena' => 100]),
+            $this->orderRow(310001, 3102, ['cena' => 200]),
+            $this->orderRow(310001, 3103, ['cena' => 300]),
+        ]);
+
+        $response->assertStatus(201);
+
+        $order = $order->fresh();
+        $this->assertEquals(2, $order->items()->count(), 'The paid item must not come back');
+        $this->assertEquals(
+            1,
+            ThirdPartyOrderItem::withTrashed()->where('external_item_id', 3101)->count(),
+            'No duplicate row for the paid item'
+        );
+        $this->assertEquals(500, $order->total, 'The paid item stays out of the total');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,18 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Services\KitchenService;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // KitchenService memoizes inventory lookups per request; the static
+        // cache outlives the per-test application, so clear it between tests.
+        KitchenService::resetInventoryCache();
+    }
 }


### PR DESCRIPTION
# Two operator requests, one PR

**1. Paid bills must not wipe food the kitchen is still cooking.** This adopts PR #6's design (which this PR supersedes — see below) and fixes four defects found in review.

**2. ebar will POST every active table at once on startup** (same endpoint, `POST /api/third-party-order`) so orders missed earlier get recorded. The endpoint previously broke down under a real batch in several ways, one of which is a **live production bug today**.

## Part 1 — Kitchen orders survive cash-out (from #6, fixed)

Invoicing now deletes only kitchen orders already handed out ("Izdate"). Unfinished ones stay on "Aktivne" with a yellow **PLAĆENO** chip and a stamp (`kitchen_orders.invoiced_at`); when the kitchen marks such an order ready it is deleted immediately instead of moving to "Izdate" (nothing could ever clear it there — the bill is settled).

Fixes on top of #6:
- The ready-delete/active-stamp policy lived in two places (`ThirdPartyOrder::deleteByExternalItemIds` reimplemented it inline). It now lives only in `KitchenService::clearForInvoice`.
- The leftover kitchen-order cleanup in the "order still has items" branch is scoped to handed-out orders — for active orders it was unreachable dead code.
- **New items arriving on an invoiced kitchen order clear the paid flag** (and ready state). Without this, food added after the stamp would vanish the moment the kitchen pressed ready.
- #6's only POS test used `STATUS_REFUNDED`, which skips `SalesService::parseAndSaveOrder` — the path waiters actually use was untested. Added a real `STATUS_PAYED` cash-out test that runs the sales pipeline.

## Part 2 — `POST /api/third-party-order` survives an all-tables payload

| Problem before | Now |
|---|---|
| No transaction; one bad table 500'd the whole request (earlier groups committed, later ones never ran) | Each `porudzbinaid` group in its own `DB::transaction`; failures reported per order in a new `summary` response field; successful groups always stay committed |
| A paid (soft-deleted) order in the payload resurrected as a live row — ghost table on the dashboard | Orders resolve against soft-deleted history: closed by an invoice **this working day** → skipped + reported in `summary.skipped_invoiced`; trashed by the 4am cleanup or in a previous working day → treated as new (ebar reuses porudzbinaid across days, so the check is deliberately bounded to the working day) |
| **Live bug:** the `onlyTrashed()` "was invoiced" check + the 4am cleanup soft-deleting *all* orders meant any order id resent after 04:00 silently never reached the kitchen | Check removed; the working-day-bounded resolution above replaces it. Invoice close paths stamp the new `third_party_orders.invoiced_at`; an indexed `third_party_invoices.external_order_id` lookup covers rows trashed before this deploy. A stornoed invoice never suppresses an order |
| Items cleared by a partial invoice (`listastavki`) were recreated as duplicate live items on resend, inflating the total | Trashed items with the paid stamp are skipped and stay out of the recomputed total |
| One Pusher HTTP call per order + unindexable `sku + 0 = ?` scans per kitchen item → timeout risk on 40 tables → ebar retries → duplicates | One `tables-update` + one `kitchen-update` per request; request-scoped memo for inventory lookups |
| Rows with missing/invalid `porudzbinaid` collapsed into a shared order `0` that silently overwrote its own items | Skipped and counted in `summary.invalid_rows`, warning logged |
| Full request body logged on every request | Bodies over 50 rows logged as row count + order ids |
| A client retry after a timeout could interleave with the still-running first request | `Cache::lock` around the handler (Laravel 9.52 file driver supports atomic locks); 429 on lock timeout. Payloads capped at 5000 rows (a 40-table sync is ~600) |

Response stays backward compatible (`success`/`message`/`data` unchanged) with `summary` added:

```json
"summary": {"processed": 38, "created": 3, "updated": 35,
            "skipped_invoiced": [104001], "invalid_rows": 0, "failed": []}
```

Per the operator's answers: orders missing from a payload are **not** closed (unchanged behavior — his system removes them via invoices), and resent already-closed orders are skipped with a warning logged.

Also: `kitchen:cleanup` now uses `Schema::disableForeignKeyConstraints()` instead of MySQL-only `SET FOREIGN_KEY_CHECKS`, so the suite runs on sqlite too.

## Review fixes (second commit)

A high-effort code review of the first commit confirmed three bugs in the new logic (each reproduced by an executed test before fixing) plus one contract regression. All fixed in `5f5849d`:

1. **Storno reopens the table.** A stornoed bill left the order's `invoiced_at` stamp in place, so the reopened table was skipped as "already paid" until 4am. `markAsStorno()` now clears the stamp on the trashed orders it references — covering both storno entry points (the scheduler's storno button and ebar's `stornoreferenceid`).
2. **Routine resends no longer delete paid-but-uncooked dishes from the kitchen.** The kitchen prune now keeps items whose order item carries the new item-level paid stamp (see below) — preserving exactly the food this PR promises to keep on the display.
3. **An item removed and later re-added with the same `stavkaid` is restored, not silently dropped.** Root cause of 2+3: a soft-deleted item couldn't say *why* it was deleted. New nullable **`third_party_order_items.invoiced_at`** (third migration), stamped by the invoice close paths: trashed+stamped → paid, skip; trashed without stamp → pruned earlier, restore on resend.
4. **Error contract restored:** any failed order group returns **500** (as production does today), not 201-with-a-buried-failure — successful groups stay committed, and since resends are idempotent a client retry re-syncs only what failed. Plus: the response now eager-loads items in one query instead of one per order.

Deliberately deferred to keep the diff minimal: removing the unused `ThirdPartyOrder::deleteByExternalOrderId` (dead code, zero runtime effect).

**Transition note:** items partially paid *before* this deploys carry no item-level stamp, so one resend on deploy day restores them once — still strictly better than current production, which recreates them as duplicates.

**Second-app check:** the other app using this system (`employee-scheduler`) was audited — it shares **no database and no models** with this repo and consumes only the third-party-invoice read/action endpoints, `/api/settings`, and `/public/sales/import`. None of their response shapes, status semantics, or request contracts change in this PR. The one shared code path is `markAsStorno()` (its storno button), where fix 1's behavior is exactly what's intended from either caller.

## Migrations

Three nullable-timestamp migrations (`kitchen_orders.invoiced_at`, `third_party_orders.invoiced_at`, `third_party_order_items.invoiced_at`), all with clean `down()` — safe to deploy and roll back.

## Tests

New `tests/Feature/ThirdPartyOrderBatchTest.php` (16 scenarios): 30-table snapshot with broadcast counting, idempotent double-post, per-order isolation (one bad group → 500, rest committed), invalid-row hygiene, oversized payload, paid-order resend skipped, retroactive invoice check, stornoed invoice allows resend, **id reused after a previous working day is created** (the reason the settled-check is working-day-bounded), 4am-cleanup resend reaches the kitchen (regression for the live bug), partial-invoice item not resurrected, **storno reopens the table same working day**, **resend keeps paid-but-unprepared dish on the kitchen display**, **removed-then-re-added item restored**. Plus new/reworked cases in `KitchenOrderTest`.

Suite run locally (no CI in this repo) on sqlite `:memory:` via a local `.env` — `phpunit.xml` untouched:

```
POS suites (ThirdPartyOrder/Batch/Kitchen/InvoiceClearing/Warehouse/Reports/Broadcast):
OK (156 tests, 817 assertions)

Full suite: Tests: 173, Assertions: 823, Errors: 11, Failures: 3
```

The 14 non-passing tests are all `tests/Feature/Auth/*` Breeze scaffolding — verified to fail **identically on pristine `main`** in this environment (missing auth views/routes), untouched by this PR.

Load shape, measured through the real endpoint (Pusher mocked): **600 rows / 40 tables → ~0.4 s, exactly 2 broadcasts** (previously 41 sequential Pusher HTTP round-trips per sync).

## Supersedes #6

This branch cherry-picks #6's commit and fixes it in place — #6 should be closed without merging.

## Out of scope, worth knowing

- `tp_test_script.py:5` has a live-looking `EXTERNAL_INVOICE_API_KEY` committed at the repo root — rotate that key and strip the file.
- `/api/backoffice/*` routes have no auth middleware (including `DELETE third-party-invoices/{id}`).
- `VerifyExternalApiKey` compares with `!==` (not `hash_equals`) and the external group has no rate limiting.
- POS `InvoiceController::store` runs without a transaction, unlike the third-party invoice path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131RNrdPYjP9vMbdSqDnASk